### PR TITLE
update config so that the 'url utils' lib is included

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/*
 *.tgz
+
+# build artifacts
+index.js
+url.js

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "@mitodl/course-search-utils",
   "version": "1.0.1",
   "description": "JS utils for interacting with MIT Open Course search",
-  "main": "dist/index.js",
+  "main": "index.js",
   "module": "src/index.js",
+  "files": [
+    "url.js",
+    "src/"
+  ],
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,16 @@
 const path = require("path")
 
 module.exports = {
-  entry: "./src/index.js",
+  entry: {
+    index: "./src/index.js",
+    url: "./src/url_utils",
+  },
   output: {
-    filename: "index.js",
-    path: path.resolve(__dirname, "dist"),
+    filename: "[name].js",
+    path: __dirname,
     library: "course-search-utils",
     libraryTarget: "umd"
   },
-
   module: {
     rules: [
       {


### PR DESCRIPTION
small change to build config

to test do the following:

1. run `npm pack` to generate a `.tgz` file for the package
2. start a fresh npm package somewhere: 
    ```
    mkdir /tmp/test-course-utils
    cd /tmp/test-course-utils
    npm init
    npm install /path/to/course-utils.tgz # or whatever the .tgz file is called
    ```
3. test that you have the right files in `node_modules`. `tree node_modules/@mitodl/course-search-utils` should look like this:
    ```
    node_modules/@mitodl/course-search-utils
   ├── index.js
   ├── package.json
   ├── README.md
   ├── src
   │   ├── constants.js
   │   ├── index.js
   │   ├── index.test.js
   │   ├── test_setup.js
   │   ├── test_util.js
   │   ├── url_utils.js
   │   └── url_utils.test.js
   └── url.js

   1 directory, 11 files
   ```
4. test that you can require `@mitodl/course-search-utils/url` in `node` without getting a 'module not found' error (you'll get a 'window is not defined' error because you're in node and not hte browser - that's ok and expected)