### PR TITLE
add support for department name facet

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,8 @@
   "version": "1.0.4",
   "description": "JS utils for interacting with MIT Open Course search",
   "main": "dist/index.js",
-  "module": "src/index.js",
   "files": [
-    "dist/",
-    "src/"
+    "dist/"
   ],
   "scripts": {
     "test": "jest",

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,9 +20,10 @@ export const LR_TYPE_ALL = [
 ]
 
 export const INITIAL_FACET_STATE = {
-  audience:      [],
-  certification: [],
-  offered_by:    [],
-  topics:        [],
-  type:          []
+  audience:        [],
+  certification:   [],
+  offered_by:      [],
+  topics:          [],
+  type:            [],
+  department_name: []
 }

--- a/src/url_utils.js
+++ b/src/url_utils.js
@@ -8,23 +8,25 @@ export const toArray = obj =>
 const urlParamToArray = param => _.union(toArray(param) || [])
 
 export const deserializeSearchParams = location => {
-  const { type, o, t, q, a, c } = qs.parse(location.search)
+  const { type, o, t, q, a, c, d } = qs.parse(location.search)
 
   return {
     text:         q,
     activeFacets: {
-      audience:      urlParamToArray(a),
-      certification: urlParamToArray(c),
-      type:          urlParamToArray(type),
-      offered_by:    urlParamToArray(o),
-      topics:        urlParamToArray(t)
+      audience:        urlParamToArray(a),
+      certification:   urlParamToArray(c),
+      type:            urlParamToArray(type),
+      offered_by:      urlParamToArray(o),
+      topics:          urlParamToArray(t),
+      department_name: urlParamToArray(d)
     }
   }
 }
 
 export const serializeSearchParams = ({ text, activeFacets }) => {
   // eslint-disable-next-line camelcase
-  const { type, offered_by, topics, audience, certification } = activeFacets
+  const { type, offered_by, topics, audience, certification, department_name } =
+    activeFacets ?? {}
 
   return qs.stringify({
     q: text || undefined,
@@ -32,6 +34,7 @@ export const serializeSearchParams = ({ text, activeFacets }) => {
     a: audience,
     c: certification,
     o: offered_by,
-    t: topics
+    t: topics,
+    d: department_name
   })
 }

--- a/src/url_utils.test.js
+++ b/src/url_utils.test.js
@@ -9,11 +9,12 @@ describe("course search library", () => {
     it("should deserialize text from the URL", () => {
       expect(deserializeSearchParams({ search: "q=The Best Course" })).toEqual({
         activeFacets: {
-          audience:      [],
-          certification: [],
-          offered_by:    [],
-          topics:        [],
-          type:          []
+          audience:        [],
+          certification:   [],
+          offered_by:      [],
+          topics:          [],
+          type:            [],
+          department_name: []
         },
         text: "The Best Course"
       })
@@ -22,11 +23,26 @@ describe("course search library", () => {
     it("should deserialize offered by", () => {
       expect(deserializeSearchParams({ search: "o=MITx" })).toEqual({
         activeFacets: {
-          audience:      [],
-          certification: [],
-          offered_by:    ["MITx"],
-          topics:        [],
-          type:          []
+          audience:        [],
+          certification:   [],
+          offered_by:      ["MITx"],
+          topics:          [],
+          type:            [],
+          department_name: []
+        },
+        text: undefined
+      })
+    })
+
+    it("should deserialize department_name", () => {
+      expect(deserializeSearchParams({ search: "d=Philosophy" })).toEqual({
+        activeFacets: {
+          audience:        [],
+          certification:   [],
+          offered_by:      [],
+          topics:          [],
+          type:            [],
+          department_name: ["Philosophy"]
         },
         text: undefined
       })
@@ -50,7 +66,8 @@ describe("course search library", () => {
             "Computer Science",
             "Electronics"
           ],
-          type: []
+          type:            [],
+          department_name: []
         },
         text: undefined
       })
@@ -59,11 +76,12 @@ describe("course search library", () => {
     it("should deserialize type from the URL", () => {
       expect(deserializeSearchParams({ search: "type=course" })).toEqual({
         activeFacets: {
-          audience:      [],
-          certification: [],
-          offered_by:    [],
-          topics:        [],
-          type:          ["course"]
+          audience:        [],
+          certification:   [],
+          offered_by:      [],
+          topics:          [],
+          type:            ["course"],
+          department_name: []
         },
         text: undefined
       })
@@ -72,11 +90,12 @@ describe("course search library", () => {
     it("should deserialize audience from the URL", () => {
       expect(deserializeSearchParams({ search: "a=Open%20Content" })).toEqual({
         activeFacets: {
-          audience:      ["Open Content"],
-          certification: [],
-          offered_by:    [],
-          topics:        [],
-          type:          []
+          audience:        ["Open Content"],
+          certification:   [],
+          offered_by:      [],
+          topics:          [],
+          type:            [],
+          department_name: []
         },
         text: undefined
       })
@@ -85,11 +104,12 @@ describe("course search library", () => {
     it("should deserialize certification from the URL", () => {
       expect(deserializeSearchParams({ search: "c=Certification" })).toEqual({
         activeFacets: {
-          audience:      [],
-          certification: ["Certification"],
-          offered_by:    [],
-          topics:        [],
-          type:          []
+          audience:        [],
+          certification:   ["Certification"],
+          offered_by:      [],
+          topics:          [],
+          type:            [],
+          department_name: []
         },
         text: undefined
       })
@@ -98,11 +118,12 @@ describe("course search library", () => {
     it("should ignore unknown params", () => {
       expect(deserializeSearchParams({ search: "eeee=beeeeeep" })).toEqual({
         activeFacets: {
-          audience:      [],
-          certification: [],
-          offered_by:    [],
-          topics:        [],
-          type:          []
+          audience:        [],
+          certification:   [],
+          offered_by:      [],
+          topics:          [],
+          type:            [],
+          department_name: []
         },
         text: undefined
       })
@@ -110,6 +131,10 @@ describe("course search library", () => {
   })
 
   describe("serializeSearchParams", () => {
+    it("should be ok with missing facets", () => {
+      expect(serializeSearchParams({ text: "hey!" })).toEqual("q=hey%21")
+    })
+
     it("should serialize text to URL", () => {
       expect(
         serializeSearchParams({


### PR DESCRIPTION
this adds support for the department name facet. I added it to the `INITIAL_FACET_STATE` constant, as well as to our `serializeSearchParams` and `deserializeSearchParams` functions.

this is part of mitodl/hugo-course-publisher#217