### PR TITLE
Fix edge cases regarding back button behavior

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,7 @@ export const useCourseSearch = (
     return () => {
       unlisten()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const loadMore = useCallback(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,12 +173,14 @@ export const useCourseSearch = (
       await runSearch(text, searchFacets, nextFrom)
 
       // search is updated, now echo params to URL bar
-      const currentSearch = window.location.search
+      const currentSearch = serializeSearchParams(
+        deserializeSearchParams(window.location)
+      )
       const newSearch = serializeSearchParams({
         text,
         activeFacets
       })
-      if (`?${newSearch}` !== currentSearch) {
+      if (currentSearch !== newSearch) {
         history.push(`?${newSearch}`)
       }
     },
@@ -191,9 +193,8 @@ export const useCourseSearch = (
       clearSearch()
       setText(text)
       setActiveFacets(activeFacets)
-      internalRunSearch(text, activeFacets)
     },
-    [internalRunSearch, clearSearch, setText, setActiveFacets]
+    [clearSearch, setText, setActiveFacets]
   )
 
   const clearText = useCallback(
@@ -238,7 +239,7 @@ export const useCourseSearch = (
     return () => {
       unlisten()
     }
-  })
+  }, [])
 
   const loadMore = useCallback(() => {
     if (!loaded) {

--- a/src/test_setup.ts
+++ b/src/test_setup.ts
@@ -22,12 +22,12 @@ Object.defineProperty(window, "location", {
     if (!value.startsWith("http")) {
       value = `http://fake${value}`
     }
-    window._URL = value
+    window._location = value
   },
 
   get: () => {
     if (window._location) {
-      return window._location
+      return new URL(window._location)
     } else {
       const location = new Location()
       window._location = location


### PR DESCRIPTION
Part of https://github.com/mitodl/ocw-www/issues/94

Fixes a couple issues:
 - search was being run twice. The extra `internalRunSearch` was removed from `initSearch`. Instead it will trigger an update in the `useDidMountEffect` function
 - Clicking the search button on the home page directed to  `/search/?q=` which was updated to `/search/?`. This caused two URLs to be pushed onto the stack which broke the back button for backing out to the home page. This should now compare the sanitized versions of the search parameters with each other.