### PR TITLE
Implement sort parameter

### DIFF
--- a/src/url_utils.test.ts
+++ b/src/url_utils.test.ts
@@ -21,7 +21,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: "The Best Course"
+        text: "The Best Course",
+        sort: null
       })
     })
 
@@ -38,7 +39,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -55,7 +57,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -83,7 +86,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -100,7 +104,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -117,7 +122,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -134,7 +140,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -151,7 +158,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -178,7 +186,8 @@ describe("course search library", () => {
             "Media Assignments with Examples"
           ]
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
 
@@ -199,7 +208,50 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       ["Assignments", "Exams", "Lecture Notes"]
         },
-        text: ""
+        text: "",
+        sort: null
+      })
+    })
+
+    it("should deserialize an ascending sort param", () => {
+      expect(deserializeSearchParams({ search: "s=coursenum" })).toEqual({
+        activeFacets: {
+          audience:            [],
+          certification:       [],
+          offered_by:          [],
+          topics:              [],
+          type:                [],
+          department_name:     [],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
+        },
+        text: "",
+        sort: {
+          field:  "coursenum",
+          option: "asc"
+        }
+      })
+    })
+
+    it("should deserialize a descending sort param", () => {
+      expect(deserializeSearchParams({ search: "s=-coursenum" })).toEqual({
+        activeFacets: {
+          audience:            [],
+          certification:       [],
+          offered_by:          [],
+          topics:              [],
+          type:                [],
+          department_name:     [],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
+        },
+        text: "",
+        sort: {
+          field:  "coursenum",
+          option: "desc"
+        }
       })
     })
 
@@ -216,7 +268,8 @@ describe("course search library", () => {
           course_feature_tags: [],
           resource_type:       []
         },
-        text: ""
+        text: "",
+        sort: null
       })
     })
   })
@@ -337,6 +390,28 @@ describe("course search library", () => {
           }
         })
       ).toEqual("r=Assignments&r=Exams&r=Lecture%20Notes")
+    })
+
+    it("should serialize sort for ascending params", () => {
+      expect(
+        serializeSearchParams({
+          sort: {
+            field:  "coursenum",
+            option: "asc"
+          }
+        })
+      ).toEqual("s=coursenum")
+    })
+
+    it("should serialize sort for descending params", () => {
+      expect(
+        serializeSearchParams({
+          sort: {
+            field:  "coursenum",
+            option: "desc"
+          }
+        })
+      ).toEqual("s=-coursenum")
     })
   })
 


### PR DESCRIPTION
Part of https://github.com/mitodl/course-search-utils/issues/21

This implements some of the behavior for a sort parameter. It will be stored in `s=` in the query string, and a `-` prefix will indicate that it's a descending argument. The web site using this library will need to implement the part which shows the option in the UI and serializes the sort option to be used with elasticsearch.

## Manual testing
 - Check out the latest open-discussions and reindex courses so that you have `coursenum` to sort on
 - On ocw-hugo-themes, check out `gs/sort`
 - In this PR, run `npm pack`. Copy the tgz file into ocw-hugo-themes, then run `yarn add ./mitodl-course-search-utils-2.2.15.tgz` for whatever your version is
 - Start open-discussions and ocw-hugo-themes
 - Go to the search page. You should see a "Sort By" dropdown. You should be able to toggle the sort with this dropdown. You should see the URL being updated as well, and you should be able to refresh the page and have the correct sort option picked based on the URL
