### PR TITLE
update some type annotations

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,24 +1,26 @@
 import { Facets } from "./url_utils"
 
-export const LR_TYPE_COURSE = "course"
-export const LR_TYPE_PROGRAM = "program"
-export const LR_TYPE_USERLIST = "userlist"
-export const LR_TYPE_LEARNINGPATH = "learningpath"
-export const LR_TYPE_VIDEO = "video"
-export const LR_TYPE_PODCAST = "podcast"
-export const LR_TYPE_PODCAST_EPISODE = "podcastepisode"
-export const FAVORITES_PSEUDO_LIST = "favorites"
-export const LR_TYPE_RESOURCEFILE = "resourcefile"
+export enum LearningResourceType {
+  Course = "course",
+  Program = "program",
+  Userlist = "userlist",
+  LearningPath = "learningpath",
+  Video = "video",
+  Podcast = "podcast",
+  PodcastEpisode = "podcastepisode",
+  PseudoList = "favorites",
+  ResourceFile = "resourcefile"
+}
 
 export const LR_TYPE_ALL = [
-  LR_TYPE_COURSE,
-  LR_TYPE_PROGRAM,
-  LR_TYPE_USERLIST,
-  LR_TYPE_LEARNINGPATH,
-  LR_TYPE_VIDEO,
-  LR_TYPE_PODCAST,
-  LR_TYPE_PODCAST_EPISODE,
-  LR_TYPE_RESOURCEFILE
+  LearningResourceType.Course,
+  LearningResourceType.Program,
+  LearningResourceType.Userlist,
+  LearningResourceType.LearningPath,
+  LearningResourceType.Video,
+  LearningResourceType.Podcast,
+  LearningResourceType.PodcastEpisode,
+  LearningResourceType.ResourceFile
 ]
 
 export const INITIAL_FACET_STATE: Facets = {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -12,10 +12,7 @@ jest.mock("history", () => ({
 
 import {
   LR_TYPE_ALL,
-  LR_TYPE_PODCAST,
-  LR_TYPE_VIDEO,
-  LR_TYPE_COURSE,
-  LR_TYPE_RESOURCEFILE,
+  LearningResourceType,
   INITIAL_FACET_STATE
 } from "./constants"
 
@@ -303,15 +300,15 @@ describe("useCourseSearch", () => {
       // @ts-ignore
       wrapper.find(".toggleFacets").prop("onClick")([
         ["topic", "mathematics", true],
-        ["type", LR_TYPE_COURSE, false],
-        ["type", LR_TYPE_RESOURCEFILE, true]
+        ["type", LearningResourceType.Course, false],
+        ["type", LearningResourceType.ResourceFile, true]
       ])
     })
     checkSearchCall(runSearch, [
       "",
       {
         ...INITIAL_FACET_STATE,
-        type:  [LR_TYPE_RESOURCEFILE],
+        type:  [LearningResourceType.ResourceFile],
         topic: ["mathematics"]
       },
       0,
@@ -341,9 +338,9 @@ describe("useCourseSearch", () => {
     // @ts-ignore
     expect(facetOptions("type")).toEqual({
       buckets: [
-        { key: LR_TYPE_VIDEO, doc_count: 8156 },
-        { key: LR_TYPE_COURSE, doc_count: 2508 },
-        { key: LR_TYPE_PODCAST, doc_count: 1180 }
+        { key: LearningResourceType.Video, doc_count: 8156 },
+        { key: LearningResourceType.Course, doc_count: 2508 },
+        { key: LearningResourceType.Podcast, doc_count: 1180 }
       ]
     })
     // @ts-ignore
@@ -368,9 +365,9 @@ describe("useCourseSearch", () => {
     // @ts-ignore
     expect(facetOptions("type")).toEqual({
       buckets: [
-        { key: LR_TYPE_VIDEO, doc_count: 8156 },
-        { key: LR_TYPE_COURSE, doc_count: 2508 },
-        { key: LR_TYPE_PODCAST, doc_count: 1180 },
+        { key: LearningResourceType.Video, doc_count: 8156 },
+        { key: LearningResourceType.Course, doc_count: 2508 },
+        { key: LearningResourceType.Podcast, doc_count: 1180 },
         { key: "Obstacle Course", doc_count: 0 }
       ]
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,7 @@ import { createBrowserHistory } from "history"
 
 import {
   LR_TYPE_ALL,
-  LR_TYPE_LEARNINGPATH,
-  LR_TYPE_USERLIST,
-  LR_TYPE_PODCAST,
-  LR_TYPE_PODCAST_EPISODE,
+  LearningResourceType,
   INITIAL_FACET_STATE
 } from "./constants"
 import {
@@ -30,13 +27,13 @@ import { useDidMountEffect } from "./hooks"
 
 export const emptyOrNil = either(isEmpty, isNil)
 
-type Aggregation = {
+export type Aggregation = {
   doc_count_error_upper_bound?: number // eslint-disable-line camelcase
   sum_other_doc_count?: number // eslint-disable-line camelcase
   buckets: Array<{ key: string; doc_count: number }> // eslint-disable-line camelcase
 }
 
-type Aggregations = Map<string, Aggregation>
+export type Aggregations = Map<string, Aggregation>
 
 export const mergeFacetResults = (...args: Aggregation[]): Aggregation => ({
   buckets: args
@@ -185,16 +182,16 @@ export const useCourseSearch = (
       const { activeFacets, sort } = activeFacetsAndSort
       const searchFacets = clone(activeFacets)
 
-      if (emptyOrNil(searchFacets.type)) {
-        searchFacets.type = LR_TYPE_ALL
-      } else {
-        if (searchFacets.type.includes(LR_TYPE_PODCAST)) {
-          searchFacets.type.push(LR_TYPE_PODCAST_EPISODE)
+      if (searchFacets.type !== undefined && searchFacets.type.length > 0) {
+        if (searchFacets.type.includes(LearningResourceType.Podcast)) {
+          searchFacets.type.push(LearningResourceType.PodcastEpisode)
         }
 
-        if (searchFacets.type.includes(LR_TYPE_USERLIST)) {
-          searchFacets.type.push(LR_TYPE_LEARNINGPATH)
+        if (searchFacets.type.includes(LearningResourceType.Userlist)) {
+          searchFacets.type.push(LearningResourceType.LearningPath)
         }
+      } else {
+        searchFacets.type = LR_TYPE_ALL
       }
 
       await runSearch(text, searchFacets, nextFrom, sort)

--- a/src/url_utils.ts
+++ b/src/url_utils.ts
@@ -11,15 +11,15 @@ const urlParamToArray = (param: ParsedParam): string[] =>
   _.union(toArray(param) || [])
 
 export interface Facets {
-  audience: string[]
-  certification: string[]
-  type: string[]
-  offered_by: string[] // eslint-disable-line camelcase
-  topics: string[]
-  department_name: string[] // eslint-disable-line camelcase
-  level: string[]
-  course_feature_tags: string[] // eslint-disable-line camelcase
-  resource_type: string[] // eslint-disable-line camelcase
+  audience?: string[]
+  certification?: string[]
+  type?: string[]
+  offered_by?: string[] // eslint-disable-line camelcase
+  topics?: string[]
+  department_name?: string[] // eslint-disable-line camelcase
+  level?: string[]
+  course_feature_tags?: string[] // eslint-disable-line camelcase
+  resource_type?: string[] // eslint-disable-line camelcase
 }
 
 export interface SortParam {


### PR DESCRIPTION
This basically

- makes all the properties on the `Facets` interface optional, since we 1) treat them as such (we do a lot of `facets.whatever ?? []` before we do anything with the data) and 2) I'm working on porting over the ocw-www search code to Typescript and the existing type signatures don't play well with how we use it over there
- create a new `LearningResourceType` enum which is exported and can be then re-used elsewhere