### PR TITLE
ignore tracking code

### DIFF
--- a/src/url_utils.test.ts
+++ b/src/url_utils.test.ts
@@ -272,6 +272,31 @@ describe("course search library", () => {
         sort: null
       })
     })
+
+    it("should ignore anything after the second ?", () => {
+      expect(
+        deserializeSearchParams({
+          search: "s=-coursenum?some_tracking_string=string"
+        })
+      ).toEqual({
+        activeFacets: {
+          audience:            [],
+          certification:       [],
+          offered_by:          [],
+          topics:              [],
+          type:                [],
+          department_name:     [],
+          level:               [],
+          course_feature_tags: [],
+          resource_type:       []
+        },
+        text: "",
+        sort: {
+          field:  "coursenum",
+          option: "desc"
+        }
+      })
+    })
   })
 
   describe("serializeSearchParams", () => {

--- a/src/url_utils.ts
+++ b/src/url_utils.ts
@@ -68,7 +68,9 @@ export const deserializeSort = (sortParam: string): SortParam | null => {
 }
 
 export const deserializeSearchParams = (location: Location): SearchParams => {
-  const { type, o, t, q, a, c, d, l, f, r, s } = qs.parse(location.search)
+  const searchUrlParams = location.search.replace(/^\?/, "").split("?", 1)[0]
+
+  const { type, o, t, q, a, c, d, l, f, r, s } = qs.parse(searchUrlParams)
 
   return {
     text:         handleText(q),


### PR DESCRIPTION
closes https://github.com/mitodl/open-discussions/issues/3555

We receive some hits with hubspot tracking links that are added as `?__hstc=<id>` at the end of the url, even when the url already has search parameters. If If there is a sort parameter, this causes the error in the issue. If there isn't a sort parameter, it appends ?__hstc=<id> to the end of the last facet filter and returns a blank search result. This PR updates the code to ignore anything after the second ?

Manual testing
In this PR, run npm pack. Copy the tgz file into ocw-hugo-themes, then run yarn add ./mitodl-course-search-utils-1.5.0.tgz for whatever your version is
Start open-discussions and ocw-hugo-themes
Go to the search page. Search should work normally. Append ?__hstc=an_id to the end of the url for a search that includes a search parameter. It should be ignored