### PR TITLE
Require passing a history object [breaking change]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@ node_modules/
 dist/*
 *.tgz
 
-# build artifacts
-index.js
-url.js
 # typescript writes this file for incremental compilation
 .tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
   },
   "peerDependencies": {
     "react": "^16.13.1"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -416,9 +416,12 @@ describe("useCourseSearch", () => {
   })
 
   it("should initialize with search parameters from window.location", async () => {
-    const { wrapper } = render({}, {
-      initialEntries: ["/search?q=sometext&t=Science&s=sortfield"]
-    })
+    const { wrapper } = render(
+      {},
+      {
+        initialEntries: ["/search?q=sometext&t=Science&s=sortfield"]
+      }
+    )
     await wait(1)
 
     const facets = wrapper.find(FacetTestComponent).prop("activeFacets")
@@ -439,9 +442,12 @@ describe("useCourseSearch", () => {
   })
 
   it("should sanitize window.location params so no extra paths are pushed onto stack", async () => {
-    const { history } = render({}, {
-      initialEntries: ["/search/?q="]
-    })
+    const { history } = render(
+      {},
+      {
+        initialEntries: ["/search/?q="]
+      }
+    )
     await wait(1)
     expect(history.index).toBe(0)
   })

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { mount } from "enzyme"
 import { act } from "react-dom/test-utils"
-import { createMemoryHistory } from "history"
+import { Update, createMemoryHistory } from "history"
 
 const memoryHistory = createMemoryHistory()
 jest.mock("history", () => ({
@@ -41,7 +41,7 @@ function FacetTestComponent(props: any) {
 }
 
 function TestComponent(props: any) {
-  const { runSearch, clearSearch, facets, loaded, searchPageSize } = props
+  const { runSearch, clearSearch, facets, loaded, searchPageSize, history } = props
 
   const {
     facetOptions,
@@ -59,7 +59,7 @@ function TestComponent(props: any) {
     sort,
     updateSort,
     updateUI
-  } = useCourseSearch(runSearch, clearSearch, facets, loaded, searchPageSize)
+  } = useCourseSearch(runSearch, clearSearch, facets, loaded, searchPageSize, history)
 
   return (
     <div className="test-component">
@@ -121,7 +121,9 @@ const render = (props = {}) => {
 }
 
 describe("useCourseSearch", () => {
-  let memoryStack, memoryUnlisten
+  let memoryStack: Update[],
+    memoryUnlisten: () => void
+
   beforeEach(() => {
     // @ts-expect-error
     window.location = "http://localhost:3000/search"
@@ -462,5 +464,19 @@ describe("useCourseSearch", () => {
     expect(memoryStack[0].location.search).toBe(
       "?q=search%20text%20goes%20here"
     )
+  })
+
+  it("should update the given history when search is rerun and parameters are different", async () => {
+    const history = createMemoryHistory()
+    const { wrapper } = render({ history })
+    await wait(1)
+    wrapper
+      .find("input")
+      .simulate("change", { target: { value: "search text goes here" } })
+    wrapper.find(".submit").simulate("click")
+    await wait(1)
+
+    expect(history.index).toBe(1)
+    expect(history.location.search).toBe("?q=search%20text%20goes%20here")
   })
 })

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -41,7 +41,14 @@ function FacetTestComponent(props: any) {
 }
 
 function TestComponent(props: any) {
-  const { runSearch, clearSearch, facets, loaded, searchPageSize, history } = props
+  const {
+    runSearch,
+    clearSearch,
+    facets,
+    loaded,
+    searchPageSize,
+    history
+  } = props
 
   const {
     facetOptions,
@@ -59,7 +66,14 @@ function TestComponent(props: any) {
     sort,
     updateSort,
     updateUI
-  } = useCourseSearch(runSearch, clearSearch, facets, loaded, searchPageSize, history)
+  } = useCourseSearch(
+    runSearch,
+    clearSearch,
+    facets,
+    loaded,
+    searchPageSize,
+    history
+  )
 
   return (
     <div className="test-component">
@@ -121,8 +135,7 @@ const render = (props = {}) => {
 }
 
 describe("useCourseSearch", () => {
-  let memoryStack: Update[],
-    memoryUnlisten: () => void
+  let memoryStack: Update[], memoryUnlisten: () => void
 
   beforeEach(() => {
     // @ts-expect-error

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -5,7 +5,7 @@ import { createMemoryHistory } from "history"
 
 const memoryHistory = createMemoryHistory()
 jest.mock("history", () => ({
-  // @ts-ignore
+  // @ts-expect-error
   ...jest.requireActual("history"),
   createBrowserHistory: () => memoryHistory
 }))
@@ -121,10 +121,9 @@ const render = (props = {}) => {
 }
 
 describe("useCourseSearch", () => {
-  // @ts-ignore
   let memoryStack, memoryUnlisten
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error
     window.location = "http://localhost:3000/search"
     memoryStack = []
     memoryUnlisten = memoryHistory.listen(location => {
@@ -133,7 +132,6 @@ describe("useCourseSearch", () => {
   })
 
   afterEach(() => {
-    // @ts-ignore
     memoryUnlisten()
   })
 
@@ -230,10 +228,9 @@ describe("useCourseSearch", () => {
   it("should let you set filters, clear them", async () => {
     const { wrapper, runSearch } = render()
     act(() => {
-      // @ts-ignore
-      wrapper.find(".onUpdateFacets").prop("onClick")({
+      wrapper.find(".onUpdateFacets").prop("onClick")?.({
         target: {
-          // @ts-ignore
+          // @ts-expect-error
           name:    "topics",
           value:   "Mathematics",
           checked: true
@@ -284,7 +281,7 @@ describe("useCourseSearch", () => {
   it("should let you accept a suggestion", async () => {
     const { wrapper, runSearch } = render()
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(".accept-suggestion").prop("onClick")("my suggestion")
     })
     checkSearchCall(runSearch, [
@@ -302,7 +299,7 @@ describe("useCourseSearch", () => {
   it("should let you toggle a facet", async () => {
     const { wrapper, runSearch } = render()
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(".toggleFacet").prop("onClick")("topic", "mathematics", true)
     })
     checkSearchCall(runSearch, [
@@ -321,7 +318,7 @@ describe("useCourseSearch", () => {
   it("should let you toggle multiple facets", async () => {
     const { wrapper, runSearch } = render()
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(".toggleFacets").prop("onClick")([
         ["topic", "mathematics", true],
         ["type", LearningResourceType.Course, false],
@@ -361,7 +358,7 @@ describe("useCourseSearch", () => {
   it("should have a function for getting facet options", async () => {
     const { wrapper } = render()
     const facetOptions = wrapper.find(".facet-options").prop("onClick")
-    // @ts-ignore
+    // @ts-expect-error
     expect(facetOptions("type")).toEqual({
       buckets: [
         { key: LearningResourceType.Video, doc_count: 8156 },
@@ -369,17 +366,17 @@ describe("useCourseSearch", () => {
         { key: LearningResourceType.Podcast, doc_count: 1180 }
       ]
     })
-    // @ts-ignore
+    // @ts-expect-error
     expect(facetOptions("topics").buckets.length).toEqual(137)
   })
 
   it("should merge an empty active facet into the ones from the search backend", async () => {
     const { wrapper } = render()
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error
       wrapper.find(".onUpdateFacets").prop("onClick")({
         target: {
-          // @ts-ignore
+          // @ts-expect-error
           name:    "type",
           value:   "Obstacle Course",
           checked: true
@@ -388,7 +385,7 @@ describe("useCourseSearch", () => {
     })
     wrapper.update()
     const facetOptions = wrapper.find(".facet-options").prop("onClick")
-    // @ts-ignore
+    // @ts-expect-error
     expect(facetOptions("type")).toEqual({
       buckets: [
         { key: LearningResourceType.Video, doc_count: 8156 },
@@ -420,7 +417,7 @@ describe("useCourseSearch", () => {
   })
 
   it("should initialize with search parameters from window.location", async () => {
-    // @ts-ignore
+    // @ts-expect-error
     window.location =
       "http://localhost:3000/search/?q=sometext&t=Science&s=sortfield"
     const { wrapper } = render()
@@ -444,30 +441,24 @@ describe("useCourseSearch", () => {
   })
 
   it("should sanitize window.location params so no extra paths are pushed onto stack", async () => {
-    // @ts-ignore
+    // @ts-expect-error
     window.location = "http://localhost:3000/search/?q="
     render()
     await wait(1)
-    // @ts-ignore
     expect(memoryStack).toStrictEqual([])
   })
 
   it("should update the URL when search is rerun and parameters are different", async () => {
-    // @ts-ignore
     const { wrapper } = render()
     await wait(1)
-    // @ts-ignore
     wrapper
       .find("input")
       .simulate("change", { target: { value: "search text goes here" } })
     wrapper.find(".submit").simulate("click")
     await wait(1)
 
-    // @ts-ignore
     expect(memoryStack.length).toBe(1)
-    // @ts-ignore
     expect(memoryStack[0].action).toBe("PUSH")
-    // @ts-ignore
     expect(memoryStack[0].location.search).toBe(
       "?q=search%20text%20goes%20here"
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import React, {
 } from "react"
 import { unionWith, eqBy, prop, clone } from "ramda"
 import _ from "lodash"
-import { createBrowserHistory } from "history"
 import { History as HHistory } from "history"
 
 import {
@@ -50,8 +49,6 @@ export const mergeFacetResults = (...args: Aggregation[]): Aggregation => ({
     // @ts-ignore
     .reduce((buckets, acc) => unionWith(eqBy(prop("key")), buckets, acc))
 })
-
-const defaultHistory = createBrowserHistory()
 
 interface PreventableEvent {
   preventDefault?: () => void
@@ -98,18 +95,18 @@ export const useCourseSearch = (
   aggregations: Aggregations,
   loaded: boolean,
   searchPageSize: number,
-  history: HHistory = defaultHistory
+  history: HHistory
 ): CourseSearchResult => {
   const [incremental, setIncremental] = useState(false)
   const [from, setFrom] = useState(0)
   const [text, setText] = useState<string>(() => {
-    const { text } = deserializeSearchParams(window.location)
+    const { text } = deserializeSearchParams(history.location)
     return text
   })
   const [activeFacetsAndSort, setActiveFacetsAndSort] = useState<FacetsAndSort>(
     () => {
       const { activeFacets, sort, ui } = deserializeSearchParams(
-        window.location
+        history.location
       )
       return { activeFacets, sort, ui }
     }
@@ -244,7 +241,7 @@ export const useCourseSearch = (
 
       // search is updated, now echo params to URL bar
       const currentSearch = serializeSearchParams(
-        deserializeSearchParams(window.location)
+        deserializeSearchParams(history.location)
       )
       const newSearch = serializeSearchParams({
         text,
@@ -296,7 +293,7 @@ export const useCourseSearch = (
 
   // this is our 'on startup' useEffect call
   useEffect(() => {
-    initSearch(window.location)
+    initSearch(history.location)
 
     // dependencies intentionally left blank here, because this effect
     // needs to run only once - it's just to initialize the search state

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,10 @@ export const mergeFacetResults = (...args: Aggregation[]): Aggregation => ({
 
 const defaultHistory = createBrowserHistory()
 
+interface PreventableEvent {
+  preventDefault?: () => void
+  type?: string
+}
 interface CourseSearchResult {
   facetOptions: (group: string) => Aggregation | null
   clearAllFilters: () => void
@@ -68,7 +72,7 @@ interface CourseSearchResult {
   text: string
   sort: SortParam | null
   activeFacets: Facets
-  onSubmit: React.FormEventHandler
+  onSubmit: (e: PreventableEvent) => void
   from: number
   updateUI: (newUI: string) => void
   ui: string | null
@@ -330,7 +334,11 @@ export const useCourseSearch = (
 
   const onSubmit: CourseSearchResult["onSubmit"] = useCallback(
     e => {
-      e.preventDefault()
+      if (e.type === "submit") {
+        console.log("Submit event. Preventing default.")
+        e.preventDefault?.()
+      }
+
       internalRunSearch(text, activeFacetsAndSort)
     },
     [internalRunSearch, text, activeFacetsAndSort]

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,14 @@ interface CourseSearchResult {
   text: string
   sort: SortParam | null
   activeFacets: Facets
+  /**
+   * Callback that handles search submission. Pass this to your search input
+   * submission event target, e.g., `<form onSubmit={onSubmit} />` or
+   * `<button onClick={onSubmit} />`.
+   *
+   * The event target does not need to emit submit events, but if it does, the
+   * default form action will be prevented.
+   */
   onSubmit: (e: PreventableEvent) => void
   from: number
   updateUI: (newUI: string) => void
@@ -335,7 +343,6 @@ export const useCourseSearch = (
   const onSubmit: CourseSearchResult["onSubmit"] = useCallback(
     e => {
       if (e.type === "submit") {
-        console.log("Submit event. Preventing default.")
         e.preventDefault?.()
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,8 +58,8 @@ interface CourseSearchResult {
   clearAllFilters: () => void
   toggleFacet: (name: string, value: string, isEnbaled: boolean) => void
   toggleFacets: (facets: [string, string, boolean][]) => void
-  onUpdateFacets: React.MouseEventHandler
-  updateText: React.ChangeEventHandler
+  onUpdateFacets: React.ChangeEventHandler<HTMLInputElement>
+  updateText: React.ChangeEventHandler<HTMLInputElement>
   clearText: React.MouseEventHandler
   updateSort: React.ChangeEventHandler
   acceptSuggestion: (suggestion: string) => void
@@ -134,8 +134,8 @@ export const useCourseSearch = (
     })
   }, [setText, setActiveFacetsAndSort])
 
-  const toggleFacet = useCallback(
-    (name: string, value: string, isEnabled: boolean) => {
+  const toggleFacet: CourseSearchResult["toggleFacet"] = useCallback(
+    (name, value, isEnabled) => {
       const { activeFacets, sort, ui } = activeFacetsAndSort
       const newFacets = clone(activeFacets)
 
@@ -149,8 +149,8 @@ export const useCourseSearch = (
     [activeFacetsAndSort, setActiveFacetsAndSort]
   )
 
-  const toggleFacets = useCallback(
-    (facets: Array<[string, string, boolean]>) => {
+  const toggleFacets: CourseSearchResult["toggleFacets"] = useCallback(
+    facets => {
       const { activeFacets, sort, ui } = activeFacetsAndSort
       const newFacets = clone(activeFacets)
 
@@ -166,14 +166,8 @@ export const useCourseSearch = (
     [activeFacetsAndSort, setActiveFacetsAndSort]
   )
 
-  const onUpdateFacets = useCallback(
-    (e: MouseEvent<HTMLInputElement>) => {
-      toggleFacet(
-        (e.target as HTMLInputElement).name,
-        (e.target as HTMLInputElement).value,
-        (e.target as HTMLInputElement).checked
-      )
-    },
+  const onUpdateFacets: CourseSearchResult["onUpdateFacets"] = useCallback(
+    e => toggleFacet(e.target.name, e.target.value, e.target.checked),
     [toggleFacet]
   )
 
@@ -327,8 +321,8 @@ export const useCourseSearch = (
     internalRunSearch(text, activeFacetsAndSort)
   }, [activeFacetsAndSort])
 
-  const onSubmit = useCallback(
-    (e: FormEvent): void => {
+  const onSubmit: CourseSearchResult["onSubmit"] = useCallback(
+    e => {
       e.preventDefault()
       internalRunSearch(text, activeFacetsAndSort)
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {
+import React, {
   useState,
   useCallback,
   useEffect,
@@ -53,9 +53,27 @@ export const mergeFacetResults = (...args: Aggregation[]): Aggregation => ({
 
 const history = createBrowserHistory()
 
-// disabling rule here because all functions and values returned by the hook are
-// fully typed, so writing out the explicit return type for this thing is redundant
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+interface CourseSearchResult {
+  facetOptions: (group: string) => Aggregation | null
+  clearAllFilters: () => void
+  toggleFacet: (name: string, value: string, isEnbaled: boolean) => void
+  toggleFacets: (facets: [string, string, boolean][]) => void
+  onUpdateFacets: React.MouseEventHandler
+  updateText: React.ChangeEventHandler
+  clearText: React.MouseEventHandler
+  updateSort: React.ChangeEventHandler
+  acceptSuggestion: (suggestion: string) => void
+  loadMore: () => void
+  incremental: boolean
+  text: string
+  sort: SortParam | null
+  activeFacets: Facets
+  onSubmit: React.FormEventHandler
+  from: number
+  updateUI: (newUI: string) => void
+  ui: string | null
+}
+
 export const useCourseSearch = (
   runSearch: (
     text: string,
@@ -68,7 +86,7 @@ export const useCourseSearch = (
   aggregations: Aggregations,
   loaded: boolean,
   searchPageSize: number
-) => {
+): CourseSearchResult => {
   const [incremental, setIncremental] = useState(false)
   const [from, setFrom] = useState(0)
   const [text, setText] = useState<string>(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,13 +91,13 @@ export const useCourseSearch = (
   const [incremental, setIncremental] = useState(false)
   const [from, setFrom] = useState(0)
   const [text, setText] = useState<string>(() => {
-    const { text } = deserializeSearchParams(history.location)
+    const { text } = deserializeSearchParams(window.location)
     return text
   })
   const [activeFacetsAndSort, setActiveFacetsAndSort] = useState<FacetsAndSort>(
     () => {
       const { activeFacets, sort, ui } = deserializeSearchParams(
-        history.location
+        window.location
       )
       return { activeFacets, sort, ui }
     }
@@ -232,7 +232,7 @@ export const useCourseSearch = (
 
       // search is updated, now echo params to URL bar
       const currentSearch = serializeSearchParams(
-        deserializeSearchParams(history.location)
+        deserializeSearchParams(window.location)
       )
       const newSearch = serializeSearchParams({
         text,
@@ -284,7 +284,7 @@ export const useCourseSearch = (
 
   // this is our 'on startup' useEffect call
   useEffect(() => {
-    initSearch(history.location)
+    initSearch(window.location)
 
     // dependencies intentionally left blank here, because this effect
     // needs to run only once - it's just to initialize the search state
@@ -304,9 +304,7 @@ export const useCourseSearch = (
       }
     })
 
-    return () => {
-      unlisten()
-    }
+    return unlisten
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/test_setup.ts
+++ b/src/test_setup.ts
@@ -8,33 +8,6 @@ require("jest-fetch-mock").enableMocks()
 
 Enzyme.configure({ adapter: new Adapter() })
 
-class Location {
-  constructor() {
-    this.href = ""
-    this.search = ""
-  }
-}
-
-Object.defineProperty(window, "location", {
-  // this is a hack just to be able to assert in tests that window.location
-  // has been set to a value
-  set: value => {
-    if (!value.startsWith("http")) {
-      value = `http://fake${value}`
-    }
-    window._location = value
-  },
-
-  get: () => {
-    if (window._location) {
-      return new URL(window._location)
-    } else {
-      const location = new Location()
-      window._location = location
-      return location
-    }
-  }
-})
 
 process.env = {
   ...process.env,

--- a/src/test_setup.ts
+++ b/src/test_setup.ts
@@ -8,7 +8,6 @@ require("jest-fetch-mock").enableMocks()
 
 Enzyme.configure({ adapter: new Adapter() })
 
-
 process.env = {
   ...process.env,
   SEARCH_API_URL: "http://search-the-planet.example.com/search"

--- a/src/url_utils.ts
+++ b/src/url_utils.ts
@@ -77,8 +77,12 @@ export const deserializeUI = (uiParam: string): string | null => {
   return uiParam
 }
 
-export const deserializeSearchParams = (location: Location): SearchParams => {
-  const searchUrlParams = location.search.replace(/^\?/, "").split("?", 1)[0]
+export const deserializeSearchParams = ({
+  search
+}: {
+  search: string
+}): SearchParams => {
+  const searchUrlParams = search.replace(/^\?/, "").split("?", 1)[0]
 
   const { type, o, t, q, a, c, d, l, f, r, s, u } = qs.parse(searchUrlParams)
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/open-discussions/issues/3727

#### What's this PR do?
This PR requires consumers to pass a `history` object to `useCourseSearch`. Previously, `useCourseSearch` was using its own history object, which meant it could not be properly integrated with react router. 

Also I fixed some typescript issues.


#### How should this be manually tested?
- Follow steps in https://github.com/mitodl/open-discussions/pull/3732
- Also https://github.com/mitodl/ocw-hugo-themes/pull/842 if you want; there's no behavior change, just updates ocw-hugo-themes to account for the breaking change here.
