### PR TITLE
Support history v4 and v5

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,11 +1,30 @@
 import { Config } from '@jest/types'
 
-const config: Config.InitialOptions = {
+const common = {
   testEnvironment:  "jsdom",
   transform:          {
     "^.+\\.(t)sx?$": "@swc/jest",
   },
   setupFilesAfterEnv: ["<rootDir>src/test_setup.ts"]
+}
+
+const config: Config.InitialOptions = {
+  projects:           [
+    {
+      displayName:      "history-v4",
+      moduleNameMapper: {
+        history$: "history-v4"
+      },
+      ...common
+    },
+    {
+      displayName:      "history-v5",
+      moduleNameMapper: {
+        history$: "history-v5"
+      },
+      ...common
+    }
+  ]
 }
 
 export default config

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/mitodl/course-search-utils#readme",
   "dependencies": {
     "bodybuilder": "^2.5.0",
-    "history": "^5.0.0",
+    "history": "^4.9 || ^5.0.0",
     "query-string": "^6.13.1",
     "ramda": "^0.27.1"
   },
@@ -64,6 +64,8 @@
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "jest-fetch-mock": "^3.0.3",
+    "history-v4": "npm:history@^4.9",
+    "history-v5": "npm:history@^5.0",
     "prettier-eslint-cli": "^7.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -93,6 +93,16 @@ function TestComponent(props: any) {
   )
 }
 
+const goBack = (history4or5: { back?: () => void; goBack?: () => void }) => {
+  if (history4or5.back) {
+    return history4or5.back()
+  }
+  if (history4or5.goBack) {
+    return history4or5.goBack()
+  }
+  throw new Error("Could not find back method.")
+}
+
 const render = (props = {}, opts: MemoryHistoryOptions = {}) => {
   const runSearch = jest.fn()
   const clearSearch = jest.fn()
@@ -402,7 +412,7 @@ describe("useCourseSearch", () => {
 
     expect(wrapper.find("input").prop("value")).toBe(text)
     act(() => {
-      history.back()
+      goBack(history)
     })
     await wait(1)
     wrapper.update()

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,6 +316,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
+"@babel/runtime@^7.1.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.7.6":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
@@ -2645,7 +2652,19 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-history@^5.0.0:
+"history-v4@npm:history@^4.9":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
+"history-v5@npm:history@^5.0", "history@^4.9 || ^5.0.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -3528,7 +3547,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
   integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4167,6 +4186,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
+
 resolve.exports@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
@@ -4545,6 +4569,16 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+tiny-invariant@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
@@ -4705,6 +4739,11 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vue-eslint-parser@^8.0.1:
   version "8.3.0"


### PR DESCRIPTION
**Review after merging #40.**

When working on #36 I neglected to notice that:
- this library has always used history v5
- React Router v5 (which our projects use) requires history v4

So if we want to pass a history object to `useCourseSearch`, we should be passing a v4 history object.

This updates the project to support both history v4 and history v5, and I made #40 to support testing against both versions.

An alternative would be dropping support for v5. But... v5 is smaller (half as big) which might be nice for OCW. _Not that it's a huge library either way._ And supporting the newer version could be useful if we ever upgrade react router. So I think for now supporting both is reasonable.

### How should this be tested
1. Checkout this branch and run `yarn pack`. Copy the output to open-discussions.
    
     Assuming your repos are siblings of each other:
    ```sh
    cp mitodl-course-search-utils-v2.0.0.tgz ../open-discussions/mitodl-course-search-utils-v2.0.0.tgz
    ```
2. In open-discussions, check out [`cc/search-routing`](https://github.com/mitodl/open-discussions/pull/3732) and pull in its latest updates
3. in open-discussions, `docker compose up`.
4. in open-discussions: (@abeglova I believe you looked at [`cc/search-routing`](https://github.com/mitodl/open-discussions/pull/3732) previously. When you looked previously, **A** worked but **B** did not.)
    - **A:** On the search page, update facets and the search text. The url should update
    - **B:**  Press the "back" button in your browser. The search input would should update to match the URL. 