### PR TITLE
Ab/support variable page size

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -474,4 +474,48 @@ describe("useCourseSearch", () => {
     expect(history.index).toBe(1)
     expect(history.location.search).toBe("?q=search%20text%20goes%20here")
   })
+
+  it("should set the correct from value when searchPageSize is a number", async () => {
+    const { wrapper, runSearch } = render({
+      searchPageSize: 50
+    })
+
+    act(() => {
+      wrapper.find(".load-more").simulate("click")
+    })
+    checkSearchCall(runSearch, [
+      "",
+      {
+        ...INITIAL_FACET_STATE,
+        type: LR_TYPE_ALL
+      },
+      50,
+      null,
+      null
+    ])
+  })
+
+  it("should set the correct from value when searchPageSize is a function", async () => {
+    const pageSizeFunc = () => {
+      return 50
+    }
+
+    const { wrapper, runSearch } = render({
+      searchPageSize: pageSizeFunc
+    })
+
+    act(() => {
+      wrapper.find(".load-more").simulate("click")
+    })
+    checkSearchCall(runSearch, [
+      "",
+      {
+        ...INITIAL_FACET_STATE,
+        type: LR_TYPE_ALL
+      },
+      50,
+      null,
+      null
+    ])
+  })
 })


### PR DESCRIPTION
This pr is need to allow pageSize to depend on the ui flag. It's needed in order to release the compact search view https://github.com/mitodl/ocw-hugo-themes/pull/953 

To test:
1)Run `yarn pack`
2) Checkout `ab/set-compact-ui-live` in ocw-hugo-themes
3) Copy the tgz file to ocw-hugo-themes
4) Run `yarn add  ./mitodl-course-search-utils-v2.0.2.tgz` in ocw-hugo-themes
5) Verify that you can toggle to the compact view and you don't get repeat courses or resources. The list view should remain unchanged
6) Copy the tgz file to open-discussions
7) Run `yarn add  ./mitodl-course-search-utils-v2.0.2.tgz` in open-discussions
8) Verify that both /learn/search and /infinite/search in open-discussions remains unchanged 
