### PR TITLE
Ab/fix types bug

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -159,6 +159,7 @@ export interface SearchQueryParams {
   sort?: SortParam
   activeFacets?: Facets
   channelName?: string
+  resourceTypes?: string[]
 }
 
 const getTypes = (activeFacets: Facets | undefined) => {
@@ -178,7 +179,8 @@ export const buildSearchQuery = ({
   size,
   sort,
   activeFacets,
-  channelName
+  channelName,
+  resourceTypes
 }: SearchQueryParams): Record<string, any> => {
   let builder = bodybuilder()
 
@@ -225,7 +227,7 @@ export const buildSearchQuery = ({
     builder.sort(field, sortQuery)
   }
 
-  const types = getTypes(activeFacets)
+  const types = resourceTypes ?? getTypes(activeFacets)
   const searchText = normalizeDoubleQuotes(text)
   return emptyOrNil(
     intersection([...LR_TYPE_ALL, LearningResourceType.ResourceFile], types)


### PR DESCRIPTION
This should be tested with https://github.com/mitodl/open-discussions/pull/3987

Once  this pr is approved i will update that pr to point to course-search-utils on npm and not the branch


#### What are the relevant tickets?
closes https://github.com/mitodl/open-discussions/issues/3964

#### What's this PR do?
This pr updates course-search-utils so that both the selected types and the types that should be shown in the aggregation are passed to buildSearchQuery 

#### How should this be manually tested?
Run https://github.com/mitodl/open-discussions/pull/3987/files#diff-b95387fcdedc9cb7b3c27edce0e5e71aeecf6b46f42278b7e4c61f05c313796b verify that the resource type facet on both learn search and infinites search now work the same as other facets and you can select more than one resource type

Verify that open discussions channel search still works. The dropdown to select "profile" "comment" or "post" is broken on prod but should also work in that branch.

Point ocw_hugo_themes to open running this branch and run ocw search locally. Verify that it is also unaffected

 