### PR TITLE
move filters to course search utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/*
 
 # typescript writes this file for incremental compilation
 .tsbuildinfo
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
   "homepage": "https://github.com/mitodl/course-search-utils#readme",
   "dependencies": {
     "axios": "^1.6.7",
+    "fuse.js": "^7.0.0",
     "query-string": "^6.13.1",
-    "ramda": "^0.27.1"
+    "ramda": "^0.27.1",
+    "react-dotdotdot": "^1.3.1"
   },
   "devDependencies": {
     "@swc/core": "^1.3.0",
@@ -44,6 +46,7 @@
     "@types/enzyme": "^3.10.7",
     "@types/jest": "^29.0.1",
     "@types/lodash": "^4.14.162",
+    "@types/lodash.uppercase": "^4.3.9",
     "@types/node": "^14.6",
     "@types/ramda": "^0.27.27",
     "@types/react": "^16.9.49",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import type { Facets } from "./url_utils"
+import type { Facets } from "./facet_display/types"
 
 export enum LearningResourceType {
   Course = "course",

--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react"
+import { contains } from "ramda"
+
+import { SearchFacetItem } from "./SearchFacetItem"
+import { BucketWithLabel } from "./FacetDisplay"
+
+const MAX_DISPLAY_COUNT = 5
+const FACET_COLLAPSE_THRESHOLD = 15
+
+interface Props {
+  name: string
+  title: string
+  results: BucketWithLabel[] | null
+  selected: string[]
+  onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  expandedOnLoad: boolean
+}
+
+function SearchFacet(props: Props) {
+  const { name, title, results, selected, onUpdate, expandedOnLoad } = props
+
+  const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
+  const [showAllFacets, setShowAllFacets] = useState(false)
+
+  const titleLineIcon = showFacetList ? "arrow_drop_down" : "arrow_right"
+
+  return results && results.length === 0 ? null : (
+    <div className="facets">
+      <button
+        className="filter-section-button"
+        type="button"
+        aria-expanded={showFacetList ? "true" : "false"}
+        onClick={() => setShowFacetList(!showFacetList)}
+      >
+        {title}
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
+          {titleLineIcon}
+        </i>
+      </button>
+      {showFacetList ? (
+        <>
+          {results ?
+            results.map((facet, i) =>
+              showAllFacets ||
+                i < MAX_DISPLAY_COUNT ||
+                results.length < FACET_COLLAPSE_THRESHOLD ? (
+                  <SearchFacetItem
+                    key={i}
+                    facet={facet}
+                    isChecked={contains(facet.key, selected || [])}
+                    onUpdate={onUpdate}
+                    name={name}
+                    displayKey={facet.label}
+                  />
+                ) : null
+            ) :
+            null}
+          {results && results.length >= FACET_COLLAPSE_THRESHOLD ? (
+            <button
+              className="facet-more-less-button"
+              onClick={() => setShowAllFacets(!showAllFacets)}
+              type="button"
+            >
+              {showAllFacets ? "View less" : "View more"}
+            </button>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export default SearchFacet

--- a/src/facet_display/FacetDisplay.test.tsx
+++ b/src/facet_display/FacetDisplay.test.tsx
@@ -1,0 +1,117 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import {
+  default as FacetDisplay,
+  getDepartmentName,
+  getLevelName
+} from "./FacetDisplay"
+import { FacetManifest, Facets } from "./types"
+
+describe("FacetDisplay component", () => {
+  const facetMap: FacetManifest = [
+    {
+      name:               "topic",
+      title:              "Topics",
+      useFilterableFacet: false,
+      expandedOnLoad:     false
+    },
+    {
+      name:               "resource_type",
+      title:              "Types",
+      useFilterableFacet: false,
+      expandedOnLoad:     false
+    },
+    {
+      name:               "department",
+      title:              "Departments",
+      useFilterableFacet: false,
+      expandedOnLoad:     true,
+      labelFunction:      getDepartmentName
+    },
+    {
+      name:               "level",
+      title:              "Level",
+      useFilterableFacet: false,
+      expandedOnLoad:     true,
+      labelFunction:      getLevelName
+    }
+  ]
+
+  function setup() {
+    const activeFacets = {}
+    const facetOptions = jest.fn()
+    const clearAllFilters = jest.fn()
+    const onFacetChange = jest.fn()
+
+    const render = (props = {}) =>
+      shallow(
+        <FacetDisplay
+          facetMap={facetMap}
+          facetOptions={facetOptions}
+          activeFacets={activeFacets}
+          clearAllFilters={clearAllFilters}
+          onFacetChange={onFacetChange}
+          {...props}
+        />
+      )
+    return { render, clearAllFilters }
+  }
+
+  test("renders a FacetDisplay with expected FilterableFacets", async () => {
+    const { render } = setup()
+    const wrapper = render()
+    const facets = wrapper.children()
+    expect(facets).toHaveLength(5)
+    facets.slice(1, 5).map((facet, key) => {
+      expect(facet.prop("name")).toBe(facetMap[key].name)
+      expect(facet.prop("title")).toBe(facetMap[key].title)
+      expect(facet.prop("expandedOnLoad")).toBe(facetMap[key].expandedOnLoad)
+    })
+  })
+
+  test("shows filters which are active", () => {
+    const activeFacets: Facets = {
+      topic:         ["Academic Writing", "Accounting", "Aerodynamics"],
+      resource_type: [],
+      department:    ["1", "2"]
+    }
+
+    const { render, clearAllFilters } = setup()
+    const wrapper = render({
+      activeFacets
+    })
+    expect(
+      wrapper
+        .find(".active-search-filters")
+        .find("SearchFilter")
+        .map(el => el.prop("value"))
+    ).toEqual(["Academic Writing", "Accounting", "Aerodynamics", "1", "2"])
+    wrapper.find(".clear-all-filters-button").simulate("click")
+    expect(clearAllFilters).toHaveBeenCalled()
+  })
+
+  test("it accepts a label function to convert codes to names", () => {
+    const activeFacets: Facets = {
+      topic:         [],
+      resource_type: [],
+      department:    ["1"],
+      level:         ["graduate"]
+    }
+
+    const { render, clearAllFilters } = setup()
+    const wrapper = render({
+      activeFacets
+    })
+    expect(
+      wrapper
+        .find(".active-search-filters")
+        .find("SearchFilter")
+        .map(el =>
+          el.render().find(".active-search-filter-label").first().html()
+        )
+    ).toEqual(["Civil and Environmental Engineering", "Graduate"])
+    wrapper.find(".clear-all-filters-button").simulate("click")
+    expect(clearAllFilters).toHaveBeenCalled()
+  })
+})

--- a/src/facet_display/FacetDisplay.tsx
+++ b/src/facet_display/FacetDisplay.tsx
@@ -1,0 +1,132 @@
+import React from "react"
+import FilterableFacet from "./FilterableFacet"
+import Facet from "./Facet"
+import SearchFilter from "./SearchFilter"
+import type { FacetManifest, Facets, Aggregation, Bucket } from "./types"
+import { LEVELS, DEPARTMENTS } from "../constants"
+
+export type BucketWithLabel = Bucket & { label: string }
+
+interface Props {
+  facetMap: FacetManifest
+  facetOptions: (group: string) => Aggregation | null
+  activeFacets: Facets
+  clearAllFilters: () => void
+  onFacetChange: (name: string, value: string, isEnabled: boolean) => void
+}
+
+export const getDepartmentName = (departmentId: string): string => {
+  if (departmentId in DEPARTMENTS) {
+    return DEPARTMENTS[departmentId as keyof typeof DEPARTMENTS]
+  } else {
+    return departmentId
+  }
+}
+
+export const getLevelName = (levelValue: string): string => {
+  if (levelValue in LEVELS) {
+    return LEVELS[levelValue as keyof typeof LEVELS]
+  } else {
+    return levelValue
+  }
+}
+
+const resultsWithLabels = (
+  results: Aggregation,
+  labelFunction: ((value: string) => string) | null | undefined
+): BucketWithLabel[] => {
+  const newResults = [] as BucketWithLabel[]
+  results.map((singleFacet: Bucket) => {
+    newResults.push({
+      key:       singleFacet.key,
+      doc_count: singleFacet.doc_count,
+      label:     labelFunction ? labelFunction(singleFacet.key) : singleFacet.key
+    })
+  })
+
+  return newResults
+}
+
+const FacetDisplay = React.memo(
+  function FacetDisplay(props: Props) {
+    const {
+      facetMap,
+      facetOptions,
+      activeFacets,
+      clearAllFilters,
+      onFacetChange
+    } = props
+
+    return (
+      <>
+        <div className="active-search-filters">
+          <div className="filter-section-main-title">
+            Filters
+            <button
+              className="clear-all-filters-button"
+              type="button"
+              onClick={clearAllFilters}
+            >
+              Clear All
+            </button>
+          </div>
+          {facetMap.map(facetSetting =>
+            (activeFacets[facetSetting.name] || []).map((facet, i) => (
+              <SearchFilter
+                key={i}
+                value={facet}
+                clearFacet={() =>
+                  onFacetChange(facetSetting.name, facet, false)
+                }
+                labelFunction={facetSetting.labelFunction || null}
+              />
+            ))
+          )}
+        </div>
+        {facetMap.map((facetSetting, key) =>
+          facetSetting.useFilterableFacet ? (
+            <FilterableFacet
+              key={key}
+              results={resultsWithLabels(
+                facetOptions(facetSetting.name) || [],
+                facetSetting.labelFunction
+              )}
+              name={facetSetting.name}
+              title={facetSetting.title}
+              selected={activeFacets[facetSetting.name] || []}
+              onUpdate={e =>
+                onFacetChange(e.target.name, e.target.value, e.target.checked)
+              }
+              expandedOnLoad={facetSetting.expandedOnLoad}
+            />
+          ) : (
+            <Facet
+              key={key}
+              title={facetSetting.title}
+              name={facetSetting.name}
+              results={resultsWithLabels(
+                facetOptions(facetSetting.name) || [],
+                facetSetting.labelFunction
+              )}
+              onUpdate={e =>
+                onFacetChange(e.target.name, e.target.value, e.target.checked)
+              }
+              selected={activeFacets[facetSetting.name] || []}
+              expandedOnLoad={facetSetting.expandedOnLoad}
+            />
+          )
+        )}
+      </>
+    )
+  },
+  (prevProps, nextProps) => {
+    return (
+      prevProps.activeFacets === nextProps.activeFacets &&
+      prevProps.clearAllFilters === nextProps.clearAllFilters &&
+      prevProps.onFacetChange === nextProps.onFacetChange &&
+      prevProps.facetOptions === nextProps.facetOptions
+    )
+  }
+)
+
+export default FacetDisplay

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useCallback, useMemo } from "react"
+import { contains } from "ramda"
+import Fuse from "fuse.js"
+
+import { SearchFacetItem } from "./SearchFacetItem"
+import { BucketWithLabel } from "./FacetDisplay"
+
+// the `.search method returns records like { item, refindex }
+// where item is the facet and refIndex is it's index in the original
+// array. this helper just pulls out only the facets themselves
+const runSearch = (searcher: Fuse<BucketWithLabel>, text: string) =>
+  searcher.search(text).map(({ item }) => item)
+
+interface Props {
+  name: string
+  title: string
+  results: BucketWithLabel[] | null
+  selected: string[]
+  onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  expandedOnLoad: boolean
+}
+
+function FilterableFacet(props: Props) {
+  const { name, title, results, selected, onUpdate, expandedOnLoad } = props
+  const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
+
+  const [filterText, setFilterText] = useState("")
+
+  const handleFilterInput = useCallback(e => {
+    e.preventDefault()
+    const filterText = e.target.value || ""
+    setFilterText(filterText)
+  }, [])
+
+  const titleLineIcon = showFacetList ? "arrow_drop_down" : "arrow_right"
+
+  const filteredResults = useMemo(() => {
+    return filterText ?
+      runSearch(
+        new Fuse(results || [], { keys: ["key", "label"], threshold: 0.4 }),
+        filterText
+      ) :
+      results
+  }, [filterText, results])
+
+  const facets = (filteredResults || results) ?? []
+  return results && results.length === 0 ? null : (
+    <div className="facets filterable-facet">
+      <button
+        className="filter-section-button"
+        type="button"
+        aria-expanded={showFacetList ? "true" : "false"}
+        onClick={() => setShowFacetList(!showFacetList)}
+      >
+        {title}
+        <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
+          {titleLineIcon}
+        </i>
+      </button>
+      {showFacetList ? (
+        <>
+          <div className="input-wrapper">
+            <input
+              className="facet-filter"
+              type="text"
+              onChange={handleFilterInput}
+              value={filterText}
+              placeholder={`Search ${title || ""}`}
+            />
+            {filterText === "" ? (
+              <i
+                className="input-postfix-icon material-icons search-icon"
+                aria-hidden="true"
+              >
+                search
+              </i>
+            ) : (
+              <button
+                className="input-postfix-button"
+                type="button"
+                onClick={() => setFilterText("")}
+                aria-label="clear search text"
+              >
+                <span className="material-icons" aria-hidden="true">
+                  clear
+                </span>
+              </button>
+            )}
+          </div>
+          <div className="facet-list">
+            {facets.map((facet, i) => (
+              <SearchFacetItem
+                key={i}
+                facet={facet}
+                isChecked={contains(facet.key, selected || [])}
+                onUpdate={onUpdate}
+                name={name}
+                displayKey={facet.label}
+              />
+            ))}
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}
+
+export default FilterableFacet

--- a/src/facet_display/SanitizeFacets.test.tsx
+++ b/src/facet_display/SanitizeFacets.test.tsx
@@ -1,0 +1,46 @@
+import { Facets } from "./types"
+import { sanitizeFacets } from "./SanitizeFacets"
+import { LEVELS, DEPARTMENTS } from "../constants"
+
+describe("sanitizeFacets", () => {
+  const FACET_OPTIONS: Facets = {
+    topic:         ["Academic Writing", "Accounting", "Aerodynamics"],
+    resource_type: ["course", "program"],
+    department:    Object.keys(DEPARTMENTS),
+    level:         Object.keys(LEVELS)
+  }
+
+  test("it should remove unknown values", async () => {
+    const activeFacets: Facets = {
+      topic:      ["Academic Writing", "Bread"],
+      department: ["1", "Pasta"],
+      level:      ["graduate", "cake"]
+    }
+
+    const expected: Facets = {
+      topic:      ["Academic Writing"],
+      department: ["1"],
+      level:      ["graduate"]
+    }
+    sanitizeFacets(activeFacets, FACET_OPTIONS)
+
+    expect(activeFacets).toEqual(expected)
+  })
+
+  test("it should convert level and department names to codes", async () => {
+    const activeFacets: Facets = {
+      topic:      [],
+      department: ["Literature"],
+      level:      ["Non-Credit"]
+    }
+
+    const expected: Facets = {
+      topic:      [],
+      department: ["21L"],
+      level:      ["noncredit"]
+    }
+    sanitizeFacets(activeFacets, FACET_OPTIONS)
+
+    expect(activeFacets).toEqual(expected)
+  })
+})

--- a/src/facet_display/SanitizeFacets.tsx
+++ b/src/facet_display/SanitizeFacets.tsx
@@ -1,0 +1,45 @@
+import { Facets } from "./types"
+import { LEVELS, DEPARTMENTS } from "../constants"
+const reverseObject = (
+  stringObject: Record<string, string>
+): Record<string, string> => {
+  return Object.fromEntries(
+    Object.entries(stringObject).map(([key, value]) => [value, key])
+  )
+}
+
+export const sanitizeFacets = (
+  activeFacets: Facets,
+  allowedFacetsOptions: Facets
+): void => {
+  const reverseLevels = reverseObject(LEVELS)
+  const reverseDepartments = reverseObject(DEPARTMENTS)
+
+  if (activeFacets) {
+    Object.entries(activeFacets).forEach(([facet, values]) => {
+      if (Object.keys(allowedFacetsOptions).indexOf(facet) > -1) {
+        activeFacets[facet as keyof typeof activeFacets] = values.flatMap(
+          (facetValue: string) => {
+            if (
+              // @ts-expect-error we checked that facet is also a key of FACET_OPTION
+              allowedFacetsOptions[
+                facet as keyof typeof allowedFacetsOptions
+              ].indexOf(facetValue) > -1
+            ) {
+              return facetValue
+            } else if (facet === "level" && facetValue in reverseLevels) {
+              return reverseLevels[facetValue]
+            } else if (
+              facet === "department" &&
+              facetValue in reverseDepartments
+            ) {
+              return reverseDepartments[facetValue]
+            } else {
+              return []
+            }
+          }
+        )
+      }
+    })
+  }
+}

--- a/src/facet_display/SearchFacetItem.tsx
+++ b/src/facet_display/SearchFacetItem.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import Dotdotdot from "react-dotdotdot"
+import { Bucket } from "./types"
+
+interface Props {
+  facet: Bucket
+  isChecked: boolean
+  onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  name: string
+  displayKey: string | null
+}
+
+export const slugify = (text: string) =>
+  text
+    .split(" ")
+    .map(subString => subString.toLowerCase())
+    .join("-")
+    .replace(/[\W_]/g, "-")
+
+export function SearchFacetItem(props: Props) {
+  const { facet, isChecked, onUpdate, name, displayKey } = props
+
+  const facetId = slugify(`${name}-${facet.key}`)
+  return (
+    <div className={isChecked ? "facet-visible checked" : "facet-visible"}>
+      <input
+        type="checkbox"
+        id={facetId}
+        name={name}
+        value={facet.key}
+        checked={isChecked}
+        onChange={onUpdate}
+      />
+      <div className="facet-label">
+        <label htmlFor={facetId} className={"facet-key"}>
+          <Dotdotdot clamp={1}>{displayKey || ""}</Dotdotdot>
+        </label>
+        <div className="facet-count">{facet.doc_count}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/facet_display/SearchFilter.test.tsx
+++ b/src/facet_display/SearchFilter.test.tsx
@@ -1,0 +1,36 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import SearchFilter from "./SearchFilter"
+
+describe("SearchFilter", () => {
+  function setup() {
+    const onClickStub = jest.fn()
+
+    const render = (props = {}) =>
+      shallow(<SearchFilter clearFacet={onClickStub} value="" {...props} />)
+
+    return { render, onClickStub }
+  }
+
+  it("should render a search filter correctly", () => {
+    const value = "Upcoming"
+    const labelFunc = (input: string) => {
+      return input.toUpperCase()
+    }
+    const { render } = setup()
+    const wrapper = render({
+      value,
+      labelFunction: labelFunc
+    })
+    const label = wrapper.text()
+    expect(label.includes(value.toUpperCase())).toBeTruthy()
+  })
+
+  it("should trigger clearFacet function on click", async () => {
+    const { render, onClickStub } = setup()
+    const wrapper = render({ value: "ocw" })
+    wrapper.find(".remove-filter-button").simulate("click")
+    expect(onClickStub).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/facet_display/SearchFilter.tsx
+++ b/src/facet_display/SearchFilter.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+
+interface Props {
+  value: string
+  labelFunction?: ((value: string) => string | null) | null
+  clearFacet: () => void
+}
+
+export default function SearchFilter(props: Props) {
+  const { value, clearFacet, labelFunction } = props
+
+  return (
+    <div className="active-search-filter">
+      <div className="active-search-filter-label">
+        {labelFunction ? labelFunction(value) : value}
+      </div>
+      <button
+        className="remove-filter-button"
+        type="button"
+        onClick={clearFacet}
+        aria-label="clear filter"
+      >
+        <span className="material-icons" aria-hidden="true">
+          close
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/src/facet_display/types.ts
+++ b/src/facet_display/types.ts
@@ -1,0 +1,33 @@
+export interface Bucket {
+  key: string
+  doc_count: number
+}
+
+export type Aggregation = Bucket[]
+
+export type Aggregations = Map<string, Bucket[]>
+
+export type GetSearchPageSize = (ui: string | null) => number
+
+export type FacetKey = keyof Facets
+
+export type SingleFacetOptions = {
+  name: FacetKey
+  title: string
+  useFilterableFacet: boolean
+  expandedOnLoad: boolean
+  labelFunction?: ((value: string) => string) | null
+}
+
+export type FacetManifest = SingleFacetOptions[]
+
+export interface Facets {
+  platform?: string[]
+  offered_by?: string[]
+  topic?: string[]
+  department?: string[]
+  level?: string[]
+  course_feature?: string[]
+  resource_type?: string[]
+  content_feature_type?: string[]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,17 +13,30 @@ import type { History as HHistory } from "history"
 import { INITIAL_FACET_STATE } from "./constants"
 import {
   FacetsAndSort,
-  Facets,
   deserializeSearchParams,
   serializeSearchParams,
   SearchParams
 } from "./url_utils"
+import {
+  Facets,
+  Aggregation,
+  Aggregations,
+  GetSearchPageSize
+} from "./facet_display/types"
 import { useEffectAfterMount } from "./hooks"
 
 export * from "./constants"
 
 export * from "./url_utils"
 export * from "./open_api_generated/api"
+export * from "./facet_display/types"
+export {
+  default as FacetDisplay,
+  getDepartmentName,
+  getLevelName
+} from "./facet_display/FacetDisplay"
+export { default as FilterableFacet } from "./facet_display/FilterableFacet"
+export { sanitizeFacets } from "./facet_display/SanitizeFacets"
 
 export type {
   UseInfiniteSearchProps,
@@ -37,17 +50,6 @@ export { default as useInfiniteSearch } from "./hooks/useInfiniteSearch"
 export { default as useSearchQueryParams } from "./hooks/useSearchQueryParams"
 
 export { buildSearchUrl, SearchQueryParams } from "./search"
-
-export interface Bucket {
-  key: string
-  doc_count: number // eslint-disable-line camelcase
-}
-
-export type Aggregation = Bucket[]
-
-export type Aggregations = Map<string, Bucket[]>
-
-export type GetSearchPageSize = (ui: string | null) => number
 
 /**
  * Accounts for a difference in the listener API for v4 and v5.

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,4 +1,4 @@
-import type { Facets } from "./url_utils"
+import type { Facets } from "./facet_display/types"
 
 export interface SearchQueryParams {
   text?: string

--- a/src/url_utils.ts
+++ b/src/url_utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import * as _ from "lodash"
 import * as qs from "query-string"
+import type { Facets } from "./facet_display/types"
 
 // type for the values in the object returned by qs.parse
 type ParsedParam = string[] | string | undefined | null
@@ -10,17 +11,6 @@ export const toArray = (obj: ParsedParam): string[] | undefined =>
 
 const urlParamToArray = (param: ParsedParam): string[] =>
   _.union(toArray(param) || [])
-
-export interface Facets {
-  platform?: string[]
-  offered_by?: string[]
-  topic?: string[]
-  department?: string[]
-  level?: string[]
-  course_feature?: string[]
-  resource_type?: string[]
-  content_feature_type?: string[]
-}
 
 export interface FacetsAndSort {
   activeFacets: Facets

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/lodash.uppercase@^4.3.9":
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/@types/lodash.uppercase/-/lodash.uppercase-4.3.9.tgz#c60ba7d79f959b64565084190a38108b246a698e"
+  integrity sha512-qP8yWivvbJ2ZuaWBbf+E3LnzrECDaRIoWycqIygieFSDDHmkL3zZdQlsXJuAtMbISIMCOtk6uLuwrAUBgIGqLg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.202"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.202.tgz#f09dbd2fb082d507178b2f2a5c7e74bd72ff98f8"
+  integrity sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==
+
 "@types/lodash@^4.14.162":
   version "4.14.162"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.162.tgz"
@@ -2772,6 +2784,11 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuse.js@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-7.0.0.tgz#6573c9fcd4c8268e403b4fc7d7131ffcf99a9eb2"
+  integrity sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
@@ -3272,6 +3289,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -4135,6 +4157,13 @@ object.hasown@^1.1.2:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  integrity sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==
+  dependencies:
+    isobject "^3.0.1"
+
 object.values@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz"
@@ -4484,6 +4513,13 @@ react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-dotdotdot@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.3.1.tgz#b94324bf66cdb70e4acffe5460e4480a91135e50"
+  integrity sha512-ImqoKTD4ZdyfF/h7jdPCZur01QlZxx3A9/gZSf9mbvseNZwVTvd+dPwi/hg1UTtP+30luy2d5j0KG+XEfdBPLQ==
+  dependencies:
+    object.pick "^1.3.0"
 
 react-error-boundary@^3.1.0:
   version "3.1.4"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/course-search-utils/issues/67

### Description (What does it do?)
This pr moves facet display functionality from ocw-hugo-themes to course-search util so it can be reused in the open search

### How can this be tested?
This should be tested with https://github.com/mitodl/ocw-hugo-themes/pull/1359