### PR TITLE
Add clearFacet, useSearchParam

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,30 +1,31 @@
-import { Config } from '@jest/types'
+import { Config } from "@jest/types";
 
 const common = {
-  testEnvironment:  "jsdom",
-  transform:          {
+  testEnvironment: "jsdom",
+  transform: {
     "^.+\\.(t)sx?$": "@swc/jest",
   },
-  setupFilesAfterEnv: ["<rootDir>src/test_setup.ts"]
-}
+  setupFilesAfterEnv: ["<rootDir>src/test_setup.ts"],
+  testMatch: ["<rootDir>/src/**/*.(spec|test).ts?(x)"],
+};
 
 const config: Config.InitialOptions = {
-  projects:           [
+  projects: [
     {
-      displayName:      "history-v4",
+      displayName: "history-v4",
       moduleNameMapper: {
-        history$: "history-v4"
+        history$: "history-v4",
       },
-      ...common
+      ...common,
     },
     {
-      displayName:      "history-v5",
+      displayName: "history-v5",
       moduleNameMapper: {
-        history$: "history"
+        history$: "history",
       },
-      ...common
-    }
-  ]
-}
+      ...common,
+    },
+  ],
+};
 
-export default config
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "files": [
     "dist/"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./react-router": "./dist/react-router/index.js"
+  },
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -73,16 +77,21 @@
     "prettier-eslint-cli": "^7.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router": "^6.22.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   },
   "peerDependencies": {
     "@types/history": "^4.9",
     "history": "^4.9 || ^5.0.0",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "react-router": "^6.22.2"
   },
   "peerDependenciesMeta": {
     "history": {
+      "optional": true
+    },
+    "react-router": {
       "optional": true
     },
     "@types/history": {

--- a/src/hooks/useSearchQueryParams.test.tsx
+++ b/src/hooks/useSearchQueryParams.test.tsx
@@ -333,14 +333,12 @@ test.each([
     initial:  "?d=6&r=program",
     expected: new URLSearchParams("?d=6")
   }
-])("Turning a facet off with setFacetActive", () => {
-  const { result, searchParams } = setup({
-    initial: "?r=course&r=program&d=6"
-  })
+])("Turning a facet off with setFacetActive", ({ initial, expected }) => {
+  const { result, searchParams } = setup({ initial })
   act(() => {
     result.current.setFacetActive("resource_type", "program", false)
   })
-  expect(searchParams.current).toEqual(new URLSearchParams("?d=6"))
+  expect(searchParams.current).toEqual(expected)
 })
 
 test.each([
@@ -434,5 +432,17 @@ test("clearFacets clears all facets", () => {
   })
   expect(searchParams.current).toEqual(
     new URLSearchParams("?q=python&x=irrelevant")
+  )
+})
+
+test("clearFacet clears specified facet", () => {
+  const { result, searchParams } = setup({
+    initial: "?r=course&d=6&q=python&x=irrelevant"
+  })
+  act(() => {
+    result.current.clearFacet("resource_type")
+  })
+  expect(searchParams.current).toEqual(
+    new URLSearchParams("?d=6&q=python&x=irrelevant")
   )
 })

--- a/src/react-router/index.ts
+++ b/src/react-router/index.ts
@@ -1,0 +1,1 @@
+export { default as useSearchParams } from "./useSearchParams"

--- a/src/react-router/useSearchParams.test.tsx
+++ b/src/react-router/useSearchParams.test.tsx
@@ -1,0 +1,139 @@
+import { renderHook, act } from "@testing-library/react-hooks/dom"
+import React from "react"
+import { MemoryRouter, useNavigate } from "react-router"
+import type { MemoryRouterProps, NavigateFunction } from "react-router"
+import useSearchParams from "./useSearchParams"
+
+const setupTest = (initialEntries?: MemoryRouterProps["initialEntries"]) => {
+  let navigate: NavigateFunction = () => {
+    throw new Error("Not yet assigned")
+  }
+  const Navigator = () => {
+    const navigateFunc = useNavigate()
+    navigate = navigateFunc
+    return null
+  }
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <MemoryRouter initialEntries={initialEntries}>
+        <Navigator />
+        {children}
+      </MemoryRouter>
+    )
+  }
+  return {
+    ...renderHook(() => useSearchParams(), { wrapper: Wrapper }),
+    navigate
+  }
+}
+
+describe("useSearchParams", () => {
+  it("allows setting searchParams with an instance", async () => {
+    const { result } = setupTest()
+    const [_searchParams, setSearchParams] = result.current
+    act(() => {
+      setSearchParams(new URLSearchParams("cat=meow"))
+    })
+    expect(result.current[0].toString()).toBe("cat=meow")
+  })
+
+  it("allows setting searchParams with a function", () => {
+    const { result } = setupTest()
+    const [_searchParams, setSearchParams] = result.current
+    act(() => {
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("cat", "meow")
+        return copy
+      })
+    })
+    expect(result.current[0].toString()).toBe("cat=meow")
+  })
+
+  it("Take into account the current value of searchParams", () => {
+    const { result } = setupTest(["/?cat=meow"])
+    const [_searchParams, setSearchParams] = result.current
+    expect(result.current[0].toString()).toBe("cat=meow")
+    act(() => {
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("dog", "woof")
+        return copy
+      })
+    })
+    expect(result.current[0].toString()).toBe("cat=meow&dog=woof")
+  })
+
+  it("External navigations update searchParams", () => {
+    const { result, navigate } = setupTest()
+    act(() => {
+      navigate("/?cat=meow")
+    })
+    expect(result.current[0].toString()).toBe("cat=meow")
+  })
+
+  it("Uses current value in updater function", () => {
+    const { result } = setupTest()
+    const [_searchParams, setSearchParams] = result.current
+    act(() => {
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("cat", "meow")
+        return copy
+      })
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("dog", "woof")
+        return copy
+      })
+    })
+    expect(result.current[0].toString()).toBe("cat=meow&dog=woof")
+  })
+
+  test("Multiple searchParam updates only trigger one history stack update", () => {
+    const { result, navigate } = setupTest()
+    const [_searchParams, setSearchParams] = result.current
+
+    act(() => {
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("a", "1")
+        return copy
+      })
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("b", "2")
+        return copy
+      })
+    })
+    expect(result.current[0].toString()).toBe("a=1&b=2")
+    act(() => {
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("c", "3")
+        return copy
+      })
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("d", "4")
+        return copy
+      })
+    })
+    expect(result.current[0].toString()).toBe("a=1&b=2&c=3&d=4")
+
+    /*
+    We did two navigations above, each with two searchParams updates.
+    The purpose of two navigations was to check that hasNavigatedRef updates
+    correctly between navigations.
+    */
+
+    act(() => {
+      navigate(-1)
+    })
+    expect(result.current[0].toString()).toBe("a=1&b=2")
+    act(() => {
+      navigate(-1)
+    })
+    expect(result.current[0].toString()).toBe("")
+  })
+})

--- a/src/react-router/useSearchParams.ts
+++ b/src/react-router/useSearchParams.ts
@@ -5,7 +5,7 @@ type SearchParamsSetterValue =
   | URLSearchParams
   | ((prevSearchParams: URLSearchParams) => URLSearchParams)
 
-type SetSearchParmas = (newSearchParams: SearchParamsSetterValue) => void
+type SetSearchParams = (newSearchParams: SearchParamsSetterValue) => void
 
 /**
  * A hook for getting and setting URL Search Parameters with React Router.
@@ -30,7 +30,7 @@ type SetSearchParmas = (newSearchParams: SearchParamsSetterValue) => void
  * the ability independently update multiple search params in a single render
  * cycle.
  */
-const useSearchParams = (): [URLSearchParams, SetSearchParmas] => {
+const useSearchParams = (): [URLSearchParams, SetSearchParams] => {
   const navigate = useNavigate()
   const { search } = useLocation()
 
@@ -56,7 +56,7 @@ const useSearchParams = (): [URLSearchParams, SetSearchParmas] => {
     searchParamsRef.current = searchParams
   })
 
-  const setSearchParams: SetSearchParmas = useCallback(
+  const setSearchParams: SetSearchParams = useCallback(
     nextValue => {
       const newParams =
         typeof nextValue === "function" ?

--- a/src/react-router/useSearchParams.ts
+++ b/src/react-router/useSearchParams.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useMemo, useRef } from "react"
+import { useLocation, useNavigate } from "react-router"
+
+type SearchParamsSetterValue =
+  | URLSearchParams
+  | ((prevSearchParams: URLSearchParams) => URLSearchParams)
+
+type SetSearchParmas = (newSearchParams: SearchParamsSetterValue) => void
+
+/**
+ * A hook for getting and setting URL Search Parameters with React Router.
+ *
+ * NOTE: React Router v6 has a built-in hook for this, but it has an issue with
+ * multiple updates.
+ *
+ * With React's own `useState` hook, updater functions are passed the CURRENT
+ * value. For example:
+ * ```ts
+ * const [count, setCount] = useState(0)
+ * const incrementBy2 = () => {
+ *    setCount((prevCount) => prevCount + 1)
+ *    setCount((prevCount) => prevCount + 1)
+ * }
+ * ```
+ * Calling `incrementBy2` will increment `count` by 2: the second call to
+ * `setCount` will use the updated value from the first call.
+ *
+ * React Router's own `useSearchParams` hook does not have this behavior: it
+ * uses outdated values when multiple updates occur in a row. This inhibits
+ * the ability independently update multiple search params in a single render
+ * cycle.
+ */
+const useSearchParams = (): [URLSearchParams, SetSearchParmas] => {
+  const navigate = useNavigate()
+  const { search } = useLocation()
+
+  /**
+   * Keep track of whether navigate has been called in the current render cycle
+   * to avoid adding extra entries in the history stack.
+   */
+  const hasNavigatedRef = useRef(false)
+  const searchParams = useMemo(() => new URLSearchParams(search), [search])
+  /**
+   * Keep track of the current searchParams value so that updater functions can
+   * use the current value rather than value from previous render.
+   */
+  const searchParamsRef = useRef(searchParams)
+
+  useEffect(() => {
+    hasNavigatedRef.current = false
+    /**
+     * Each render, sync the ref with the current state value.
+     * This is necessary in case search params has changed via some source other
+     * than this hook (e.g., browser navigation).
+     */
+    searchParamsRef.current = searchParams
+  })
+
+  const setSearchParams: SetSearchParmas = useCallback(
+    nextValue => {
+      const newParams =
+        typeof nextValue === "function" ?
+          nextValue(searchParamsRef.current) :
+          nextValue
+      searchParamsRef.current = newParams
+      navigate(
+        { search: newParams.toString() },
+        { replace: hasNavigatedRef.current }
+      )
+      hasNavigatedRef.current = true
+    },
+    [navigate]
+  )
+  return [searchParams, setSearchParams]
+}
+
+export default useSearchParams

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,6 +793,11 @@
     typescript "^4.5.4"
     vue-eslint-parser "^8.0.1"
 
+"@remix-run/router@1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.2.tgz#35726510d332ba5349c6398d13259d5da184553d"
+  integrity sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.41"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz"
@@ -4493,6 +4498,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-router@^6.22.2:
+  version "6.22.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.2.tgz#27e77e4c635a5697693b922d131d773451c98a5b"
+  integrity sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==
+  dependencies:
+    "@remix-run/router" "1.15.2"
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"


### PR DESCRIPTION
### What are the relevant tickets?
#65 

### Description (What does it do?)
This PR does two thngs:

1. Adds a new callback `clearFacet` to the return of `useSearchQueryParams` for clearing a single facet.
2. Changes the implementation of `useSearchQueryParams` to NOT use the two-parameter `URLSearchParams.delete(key, value)` syntax. 
     - This has pretty bad browser support, and seems not to be supported by JSDOM's implementation. See https://caniuse.com/mdn-api_urlsearchparams_delete_value_parameter
3. Adds a new export path `@mitodl/course-search-utils/react-router` that exports hook called `useSearchParams`. **See comment for more details.**

### How can this be tested?
Test with https://github.com/mitodl/mit-open/pull/562, which uses the commit at tip of this branch.
