### PR TITLE
add hasFacets return value

### DIFF
--- a/src/hooks/useValidatedSearchParams.test.tsx
+++ b/src/hooks/useValidatedSearchParams.test.tsx
@@ -370,10 +370,7 @@ describe("useResourceSearchParams", () => {
       expected: new URLSearchParams("?q=python&x=irrelevant")
     }
   ])("clearFacets clears all facets", ({ initial, facets, expected }) => {
-    const props = { facets } as Omit<
-      UseResourceSearchParamsProps,
-      "searchParams" | "setSearchParams"
-    >
+    const props = { facets } as Pick<UseResourceSearchParamsProps, "facets">
     const { result, searchParams } = setup({ initial, props })
     act(() => {
       result.current.clearAllFacets()
@@ -381,6 +378,32 @@ describe("useResourceSearchParams", () => {
     searchParams.current.sort()
     expect(searchParams.current).toEqual(expected)
   })
+
+  test.each([
+    {
+      initial:
+        "?resource_type=course&department=6&department=8&q=python&x=irrelevant",
+      facets:   ["department"],
+      expected: true
+    },
+    {
+      initial:  "?resource_type=course",
+      facets:   ["department"],
+      expected: false
+    },
+    {
+      initial:  "?resource_type=course",
+      facets:   ["resource_type"],
+      expected: true
+    }
+  ])(
+    "hasFacets is true if and only if the searchParams include facets",
+    ({ initial, facets, expected }) => {
+      const props = { facets } as Pick<UseResourceSearchParamsProps, "facets">
+      const { result } = setup({ initial, props })
+      expect(result.current.hasFacets).toBe(expected)
+    }
+  )
 
   test("clearParam clears specified parameter", () => {
     const { result, searchParams } = setup({

--- a/src/hooks/useValidatedSearchParams.ts
+++ b/src/hooks/useValidatedSearchParams.ts
@@ -42,6 +42,10 @@ interface UseValidatedSearchParamsResult<ReqParams> {
    */
   clearAllFacets: () => void
   /**
+   * True if there are any facets in the request.
+   */
+  hasFacets: boolean
+  /**
    * Clear a particle parameter by key.
    */
   clearParam: (key: keyof ReqParams & string) => void
@@ -238,6 +242,7 @@ const useValidatedSearchParams = <ReqParams>({
   return {
     params,
     clearAllFacets,
+    hasFacets: facets.some(f => searchParams.has(f)),
     clearParam,
     patchParams,
     toggleParamValue,


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/3900

### Description (What does it do?)
This adds a `hasFacets` boolean to the result of `useResourceSearchParams`. The goal is to facilitate showing `Clear All` facet button if and only if some facets are active. 

### How can this be tested?
1. 

