### PR TITLE
remove dotdotdot

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "axios": "^1.6.7",
     "fuse.js": "^7.0.0",
     "query-string": "^6.13.1",
-    "ramda": "^0.27.1",
-    "react-dotdotdot": "^1.3.1"
+    "ramda": "^0.27.1"
   },
   "devDependencies": {
     "@swc/core": "^1.3.0",

--- a/src/facet_display/SearchFacetItem.tsx
+++ b/src/facet_display/SearchFacetItem.tsx
@@ -1,26 +1,25 @@
-import React from "react"
-import Dotdotdot from "react-dotdotdot"
-import { Bucket } from "./types"
+import React from "react";
+import { Bucket } from "./types";
 
 interface Props {
-  facet: Bucket
-  isChecked: boolean
-  onUpdate: React.ChangeEventHandler<HTMLInputElement>
-  name: string
-  displayKey: string | null
+  facet: Bucket;
+  isChecked: boolean;
+  onUpdate: React.ChangeEventHandler<HTMLInputElement>;
+  name: string;
+  displayKey: string | null;
 }
 
 export const slugify = (text: string) =>
   text
     .split(" ")
-    .map(subString => subString.toLowerCase())
+    .map((subString) => subString.toLowerCase())
     .join("-")
-    .replace(/[\W_]/g, "-")
+    .replace(/[\W_]/g, "-");
 
 export function SearchFacetItem(props: Props) {
-  const { facet, isChecked, onUpdate, name, displayKey } = props
+  const { facet, isChecked, onUpdate, name, displayKey } = props;
 
-  const facetId = slugify(`${name}-${facet.key}`)
+  const facetId = slugify(`${name}-${facet.key}`);
   return (
     <div className={isChecked ? "facet-visible checked" : "facet-visible"}>
       <input
@@ -33,10 +32,10 @@ export function SearchFacetItem(props: Props) {
       />
       <div className="facet-label">
         <label htmlFor={facetId} className={"facet-key"}>
-          <Dotdotdot clamp={1}>{displayKey || ""}</Dotdotdot>
+          {displayKey ?? ""}
         </label>
         <div className="facet-count">{facet.doc_count}</div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/facet_display/SearchFacetItem.tsx
+++ b/src/facet_display/SearchFacetItem.tsx
@@ -1,25 +1,25 @@
-import React from "react";
-import { Bucket } from "./types";
+import React from "react"
+import { Bucket } from "./types"
 
 interface Props {
-  facet: Bucket;
-  isChecked: boolean;
-  onUpdate: React.ChangeEventHandler<HTMLInputElement>;
-  name: string;
-  displayKey: string | null;
+  facet: Bucket
+  isChecked: boolean
+  onUpdate: React.ChangeEventHandler<HTMLInputElement>
+  name: string
+  displayKey: string | null
 }
 
 export const slugify = (text: string) =>
   text
     .split(" ")
-    .map((subString) => subString.toLowerCase())
+    .map(subString => subString.toLowerCase())
     .join("-")
-    .replace(/[\W_]/g, "-");
+    .replace(/[\W_]/g, "-")
 
 export function SearchFacetItem(props: Props) {
-  const { facet, isChecked, onUpdate, name, displayKey } = props;
+  const { facet, isChecked, onUpdate, name, displayKey } = props
 
-  const facetId = slugify(`${name}-${facet.key}`);
+  const facetId = slugify(`${name}-${facet.key}`)
   return (
     <div className={isChecked ? "facet-visible checked" : "facet-visible"}>
       <input
@@ -37,5 +37,5 @@ export function SearchFacetItem(props: Props) {
         <div className="facet-count">{facet.doc_count}</div>
       </div>
     </div>
-  );
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,11 +3545,6 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
 
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
-
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz"
@@ -4425,13 +4420,6 @@ object.hasown@^1.1.2:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.pick@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
-  integrity sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==
-  dependencies:
-    isobject "^3.0.1"
-
 object.values@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz"
@@ -4795,13 +4783,6 @@ react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
-
-react-dotdotdot@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/react-dotdotdot/-/react-dotdotdot-1.3.1.tgz#b94324bf66cdb70e4acffe5460e4480a91135e50"
-  integrity sha512-ImqoKTD4ZdyfF/h7jdPCZur01QlZxx3A9/gZSf9mbvseNZwVTvd+dPwi/hg1UTtP+30luy2d5j0KG+XEfdBPLQ==
-  dependencies:
-    object.pick "^1.3.0"
 
 react-error-boundary@^3.1.0:
   version "3.1.4"


### PR DESCRIPTION
### What are the relevant tickets?
- #75 
- Related to https://github.com/mitodl/mit-open/pull/896

### Description (What does it do?)
Removes `react-dotdotdot`. Consumers should use CSS to truncate text.

### Screenshots (if appropriate):
See https://github.com/mitodl/mit-open/pull/896

### How can this be tested?
See https://github.com/mitodl/mit-open/pull/896

### Additional Info
Uses
- https://github.com/mitodl/course-search-utils/pull/104

