### PR TITLE
Add an expanded classname to the facet container

### DIFF
--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -25,7 +25,9 @@ function SearchFacet(props: Props) {
   const titleLineIcon = showFacetList ? "expand_less" : "expand_more"
 
   return results && results.length === 0 ? null : (
-    <div className={`facets base-facet${showFacetList ? " facets-expanded" : ""}`}>
+    <div
+      className={`facets base-facet${showFacetList ? " facets-expanded" : ""}`}
+    >
       <button
         className="filter-section-button"
         type="button"

--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -25,7 +25,7 @@ function SearchFacet(props: Props) {
   const titleLineIcon = showFacetList ? "expand_less" : "expand_more"
 
   return results && results.length === 0 ? null : (
-    <div className="facets base-facet">
+    <div className={`facets base-facet${showFacetList ? " facets-expanded" : ""}`}>
       <button
         className="filter-section-button"
         type="button"

--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -18,7 +18,15 @@ interface Props {
 }
 
 function SearchFacet(props: Props) {
-  const { name, title, results, selected, onUpdate, expandedOnLoad, preserveItems } = props
+  const {
+    name,
+    title,
+    results,
+    selected,
+    onUpdate,
+    expandedOnLoad,
+    preserveItems
+  } = props
 
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
   const [showAllFacets, setShowAllFacets] = useState(false)

--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -14,10 +14,11 @@ interface Props {
   selected: string[]
   onUpdate: React.ChangeEventHandler<HTMLInputElement>
   expandedOnLoad: boolean
+  preserveItems?: boolean
 }
 
 function SearchFacet(props: Props) {
-  const { name, title, results, selected, onUpdate, expandedOnLoad } = props
+  const { name, title, results, selected, onUpdate, expandedOnLoad, preserveItems } = props
 
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
   const [showAllFacets, setShowAllFacets] = useState(false)
@@ -39,7 +40,7 @@ function SearchFacet(props: Props) {
           {titleLineIcon}
         </i>
       </button>
-      {showFacetList ? (
+      {showFacetList || preserveItems ? (
         <>
           {results ?
             results.map((bucket, i) =>

--- a/src/facet_display/FacetDisplay.tsx
+++ b/src/facet_display/FacetDisplay.tsx
@@ -129,6 +129,7 @@ const AvailableFacets: React.FC<Omit<FacetDisplayProps, "clearAllFilters">> = ({
               }
               selected={activeFacets[facetSettings.name] || []}
               expandedOnLoad={facetSettings.expandedOnLoad}
+              preserveItems={facetSettings.preserveItems}
             />
           )
         } else if (facetSettings.type === "filterable") {
@@ -146,6 +147,7 @@ const AvailableFacets: React.FC<Omit<FacetDisplayProps, "clearAllFilters">> = ({
               }
               selected={activeFacets[facetSettings.name] || []}
               expandedOnLoad={facetSettings.expandedOnLoad}
+              preserveItems={facetSettings.preserveItems}
             />
           )
         } else if (facetSettings.type === "group") {

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -18,10 +18,11 @@ interface Props {
   selected: string[]
   onUpdate: React.ChangeEventHandler<HTMLInputElement>
   expandedOnLoad: boolean
+  preserveItems?: boolean
 }
 
 function FilterableFacet(props: Props) {
-  const { name, title, results, selected, onUpdate, expandedOnLoad } = props
+  const { name, title, results, selected, onUpdate, expandedOnLoad, preserveItems } = props
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
 
   const [filterText, setFilterText] = useState("")
@@ -61,7 +62,7 @@ function FilterableFacet(props: Props) {
           {titleLineIcon}
         </i>
       </button>
-      {showFacetList ? (
+      {showFacetList || preserveItems ? (
         <>
           <div className="input-wrapper">
             <input

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -45,7 +45,7 @@ function FilterableFacet(props: Props) {
 
   const buckets = (filteredResults || results) ?? []
   return results && results.length === 0 ? null : (
-    <div className="facets filterable-facet">
+    <div className={`facets filterable-facet${showFacetList ? " facets-expanded" : ""}`}>
       <button
         className="filter-section-button"
         type="button"

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -45,7 +45,11 @@ function FilterableFacet(props: Props) {
 
   const buckets = (filteredResults || results) ?? []
   return results && results.length === 0 ? null : (
-    <div className={`facets filterable-facet${showFacetList ? " facets-expanded" : ""}`}>
+    <div
+      className={`facets filterable-facet${
+        showFacetList ? " facets-expanded" : ""
+      }`}
+    >
       <button
         className="filter-section-button"
         type="button"

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -22,7 +22,15 @@ interface Props {
 }
 
 function FilterableFacet(props: Props) {
-  const { name, title, results, selected, onUpdate, expandedOnLoad, preserveItems } = props
+  const {
+    name,
+    title,
+    results,
+    selected,
+    onUpdate,
+    expandedOnLoad,
+    preserveItems
+  } = props
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
 
   const [filterText, setFilterText] = useState("")

--- a/src/facet_display/types.ts
+++ b/src/facet_display/types.ts
@@ -23,6 +23,7 @@ export type SingleFacetOptions = {
   name: FacetKey
   title: string
   expandedOnLoad: boolean
+  preserveItems?: boolean
   labelFunction?: ((value: string) => string) | null
 }
 


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/hq/issues/4668

### Description (What does it do?)

- Adds a classname to the facet container when expanded so we can apply styles.

- Adds a prop `preserveItems` to the facet manifest that instructs the base and filterable facets to not remove the items from the DOM when collapsed. This is so that the accordion height can be animated with css.

### How can this be tested?

No functional change.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

