### PR TITLE
Fix history stack / client side nav

### DIFF
--- a/src/next/useSearchParams.test.tsx
+++ b/src/next/useSearchParams.test.tsx
@@ -1,10 +1,10 @@
-import { renderHook, act, waitFor } from "@testing-library/react";
-import useSearchParams from "./useSearchParams";
+import { renderHook, act, waitFor } from "@testing-library/react"
+import useSearchParams from "./useSearchParams"
 
 describe("useSearchParams > setSearchParams", () => {
   beforeEach(() => {
-    window.history.replaceState({}, "", "/");
-  });
+    window.history.replaceState({}, "", "/")
+  })
   /**
    * useSearchParams returns [searchParams, setSearchParams]
    *
@@ -16,62 +16,62 @@ describe("useSearchParams > setSearchParams", () => {
    * react components re-render appropriately. But that's NextJS's responsibility)
    */
   it("allows setting searchParams with an instance", async () => {
-    const { result } = renderHook(() => useSearchParams());
-    const [_, setSearchParams] = result.current;
+    const { result } = renderHook(() => useSearchParams())
+    const [_, setSearchParams] = result.current
     act(() => {
-      setSearchParams(new URLSearchParams("cat=meow"));
-    });
-    expect(window.location.search.toString()).toBe("?cat=meow");
-  });
+      setSearchParams(new URLSearchParams("cat=meow"))
+    })
+    expect(window.location.search.toString()).toBe("?cat=meow")
+  })
 
   it("allows setting searchParams with a function", () => {
-    const { result } = renderHook(() => useSearchParams());
-    const [_, setSearchParams] = result.current;
+    const { result } = renderHook(() => useSearchParams())
+    const [_, setSearchParams] = result.current
     act(() => {
-      setSearchParams((prev) => {
-        const copy = new URLSearchParams(prev);
-        copy.set("cat", "meow");
-        return copy;
-      });
-    });
-    expect(window.location.search).toBe("?cat=meow");
-  });
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("cat", "meow")
+        return copy
+      })
+    })
+    expect(window.location.search).toBe("?cat=meow")
+  })
 
   it("Take into account the current value of searchParams", () => {
-    window.history.replaceState({}, "", "?cat=meow");
-    const { result } = renderHook(() => useSearchParams());
-    const [_, setSearchParams] = result.current;
-    expect(window.location.search).toBe("?cat=meow");
+    window.history.replaceState({}, "", "?cat=meow")
+    const { result } = renderHook(() => useSearchParams())
+    const [_, setSearchParams] = result.current
+    expect(window.location.search).toBe("?cat=meow")
     act(() => {
-      setSearchParams((prev) => {
-        const copy = new URLSearchParams(prev);
-        copy.set("dog", "woof");
-        return copy;
-      });
-    });
-    expect(window.location.search).toBe("?cat=meow&dog=woof");
-  });
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("dog", "woof")
+        return copy
+      })
+    })
+    expect(window.location.search).toBe("?cat=meow&dog=woof")
+  })
 
   it("Multiple synchronous setSearchParams call use current value and trigger one push", async () => {
-    window.history.replaceState({}, "", "?a=1&b=2");
-    const { result } = renderHook(() => useSearchParams());
-    const [_, setSearchParams] = result.current;
+    window.history.replaceState({}, "", "?a=1&b=2")
+    const { result } = renderHook(() => useSearchParams())
+    const [_, setSearchParams] = result.current
     act(() => {
-      setSearchParams((prev) => {
-        const copy = new URLSearchParams(prev);
-        copy.set("b", "22");
-        return copy;
-      });
-      setSearchParams((prev) => {
-        const copy = new URLSearchParams(prev);
-        copy.set("c", "3");
-        return copy;
-      });
-    });
-    expect(window.location.search).toBe("?a=1&b=22&c=3");
-    window.history.back();
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("b", "22")
+        return copy
+      })
+      setSearchParams(prev => {
+        const copy = new URLSearchParams(prev)
+        copy.set("c", "3")
+        return copy
+      })
+    })
+    expect(window.location.search).toBe("?a=1&b=22&c=3")
+    window.history.back()
     await waitFor(() => {
-      expect(window.location.search).toBe("?a=1&b=2");
-    });
-  });
-});
+      expect(window.location.search).toBe("?a=1&b=2")
+    })
+  })
+})

--- a/src/next/useSearchParams.test.tsx
+++ b/src/next/useSearchParams.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import useSearchParams from "./useSearchParams";
+
+describe("useSearchParams > setSearchParams", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+  /**
+   * useSearchParams returns [searchParams, setSearchParams]
+   *
+   * We do NOT check the searchParams value in these tests, as that relies on
+   * NextJS's App Router. But it should always be in-sync with
+   * window.location.search, so we'll check that instead.
+   *
+   * (The purpose of the first arg is an immutable searchParams object, ensuring
+   * react components re-render appropriately. But that's NextJS's responsibility)
+   */
+  it("allows setting searchParams with an instance", async () => {
+    const { result } = renderHook(() => useSearchParams());
+    const [_, setSearchParams] = result.current;
+    act(() => {
+      setSearchParams(new URLSearchParams("cat=meow"));
+    });
+    expect(window.location.search.toString()).toBe("?cat=meow");
+  });
+
+  it("allows setting searchParams with a function", () => {
+    const { result } = renderHook(() => useSearchParams());
+    const [_, setSearchParams] = result.current;
+    act(() => {
+      setSearchParams((prev) => {
+        const copy = new URLSearchParams(prev);
+        copy.set("cat", "meow");
+        return copy;
+      });
+    });
+    expect(window.location.search).toBe("?cat=meow");
+  });
+
+  it("Take into account the current value of searchParams", () => {
+    window.history.replaceState({}, "", "?cat=meow");
+    const { result } = renderHook(() => useSearchParams());
+    const [_, setSearchParams] = result.current;
+    expect(window.location.search).toBe("?cat=meow");
+    act(() => {
+      setSearchParams((prev) => {
+        const copy = new URLSearchParams(prev);
+        copy.set("dog", "woof");
+        return copy;
+      });
+    });
+    expect(window.location.search).toBe("?cat=meow&dog=woof");
+  });
+
+  it("Multiple synchronous setSearchParams call use current value and trigger one push", async () => {
+    window.history.replaceState({}, "", "?a=1&b=2");
+    const { result } = renderHook(() => useSearchParams());
+    const [_, setSearchParams] = result.current;
+    act(() => {
+      setSearchParams((prev) => {
+        const copy = new URLSearchParams(prev);
+        copy.set("b", "22");
+        return copy;
+      });
+      setSearchParams((prev) => {
+        const copy = new URLSearchParams(prev);
+        copy.set("c", "3");
+        return copy;
+      });
+    });
+    expect(window.location.search).toBe("?a=1&b=22&c=3");
+    window.history.back();
+    await waitFor(() => {
+      expect(window.location.search).toBe("?a=1&b=2");
+    });
+  });
+});

--- a/src/next/useSearchParams.ts
+++ b/src/next/useSearchParams.ts
@@ -1,54 +1,66 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useSearchParams as useNextSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef } from "react"
+import { useSearchParams as useNextSearchParams } from "next/navigation"
 
 type SearchParamsSetterValue =
   | URLSearchParams
-  | ((prevSearchParams: URLSearchParams) => URLSearchParams);
+  | ((prevSearchParams: URLSearchParams) => URLSearchParams)
 
-type SetSearchParams = (newSearchParams: SearchParamsSetterValue) => void;
+type SetSearchParams = (newSearchParams: SearchParamsSetterValue) => void
 
-const useSearchParams = (): [URLSearchParams, SetSearchParams] => {
-  const search = useNextSearchParams();
-
+/**
+ * Returns a function for setting search params in the browser URL.
+ *  - the first call within a single render cycle will add a new entry in the
+ *   history stack via pushState
+ *  - subsequent calls will replace the previous entry in the history stack
+ *    and will receive the previously updated value in setter function
+ *
+ * NOTE: This is intended for use with NextJS, but could work with any framework
+ * that supports direct usage of window.history.pushState / replaceState.
+ */
+const useSetSearchParams = (): SetSearchParams => {
   /**
    * Keep track of whether navigate has been called in the current render cycle
    * to avoid adding extra entries in the history stack.
    */
-  const hasNavigatedRef = useRef(false);
-  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
-  /**
-   * Keep track of the current searchParams value so that updater functions can
-   * use the current value rather than value from previous render.
-   */
-  const searchParamsRef = useRef(searchParams);
+  const hasNavigatedRef = useRef(false)
 
   useEffect(() => {
-    hasNavigatedRef.current = false;
-    /**
-     * Each render, sync the ref with the current state value.
-     * This is necessary in case search params has changed via some source other
-     * than this hook (e.g., browser navigation).
-     */
-    searchParamsRef.current = searchParams;
-  });
+    hasNavigatedRef.current = false
+  })
 
-  const setSearchParams: SetSearchParams = useCallback((nextValue) => {
+  const setSearchParams: SetSearchParams = useCallback(nextValue => {
     const newParams =
-      typeof nextValue === "function"
-        ? nextValue(searchParamsRef.current)
-        : nextValue;
-
-    searchParamsRef.current = newParams;
+      typeof nextValue === "function" ?
+        nextValue(new URLSearchParams(window.location.search)) :
+        nextValue
 
     if (hasNavigatedRef.current) {
-      window.history.replaceState({}, "", `?${newParams}`);
+      window.history.replaceState({}, "", `?${newParams}`)
     } else {
-      window.history.pushState({}, "", `?${newParams}`);
+      window.history.pushState({}, "", `?${newParams}`)
     }
 
-    hasNavigatedRef.current = true;
-  }, []);
-  return [searchParams, setSearchParams];
-};
+    hasNavigatedRef.current = true
+  }, [])
+  return setSearchParams
+}
 
-export default useSearchParams;
+/**
+ * Like react `useState`, but for getting/setting search params in NextJS
+ * App Router. The setter is client-side only and will not trigger a call
+ * to the server. (Uses `window.history.pushState` internally, not `useRouter`).
+ *
+ * ```ts
+ * const [searchParams, setSearchParams] = useSearchParams();
+ * ```
+ * Where:
+ * - `searchParams` is the search params objet from `next/navigation`'s useSearchParams
+ * - `setSearchParams` is like React's `useState` setter:
+ *    - arg can be a single value or function (current => next)
+ *    - multiple synchronous calls to setSearchParams trigger only one pushState
+ */
+const useSearchParams = (): [URLSearchParams, SetSearchParams] => {
+  return [useNextSearchParams(), useSetSearchParams()]
+}
+
+export default useSearchParams


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/5735 via PR https://github.com/mitodl/mit-open/pull/1680

### Description (What does it do?)
This PR changes our NextJS `useSearchParams` to be client-only. Fore more details, see comments.

### How can this be tested?
Test via https://github.com/mitodl/mit-open/pull/1680

