### PR TITLE
add facet-transitioning class

### DIFF
--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -29,16 +29,21 @@ function SearchFacet(props: Props) {
 
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
   const [showAllFacets, setShowAllFacets] = useState(false)
+  const [transitioning, setTransitioning] = useState(false)
 
   return results && results.length === 0 ? null : (
     <div
-      className={`facets base-facet${showFacetList ? " facets-expanded" : ""}`}
+      className={`facets base-facet${showFacetList ? " facets-expanded" : (transitioning ? " facets-transitioning" : "")}`}
+      onTransitionEnd={() => setTransitioning(false)}
     >
       <button
         className="filter-section-button"
         type="button"
         aria-expanded={showFacetList ? "true" : "false"}
-        onClick={() => setShowFacetList(!showFacetList)}
+        onClick={() => {
+          setTransitioning(true)
+          setShowFacetList(!showFacetList)
+        }}
       >
         {title}
         <i aria-hidden="true">

--- a/src/facet_display/Facet.tsx
+++ b/src/facet_display/Facet.tsx
@@ -33,7 +33,7 @@ function SearchFacet(props: Props) {
 
   return results && results.length === 0 ? null : (
     <div
-      className={`facets base-facet${showFacetList ? " facets-expanded" : (transitioning ? " facets-transitioning" : "")}`}
+      className={`facets base-facet${showFacetList ? " facets-expanded" : transitioning ? " facets-transitioning" : ""}`}
       onTransitionEnd={() => setTransitioning(false)}
     >
       <button

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -36,8 +36,8 @@ function FilterableFacet(props: Props) {
     preserveItems
   } = props
   const [showFacetList, setShowFacetList] = useState(expandedOnLoad)
-
   const [filterText, setFilterText] = useState("")
+  const [transitioning, setTransitioning] = useState(false)
 
   const handleFilterInput = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -61,14 +61,18 @@ function FilterableFacet(props: Props) {
   return results && results.length === 0 ? null : (
     <div
       className={`facets filterable-facet${
-        showFacetList ? " facets-expanded" : ""
+        showFacetList ? " facets-expanded" : (transitioning ? " facets-transitioning" : "")
       }`}
+      onTransitionEnd={() => setTransitioning(false)}
     >
       <button
         className="filter-section-button"
         type="button"
         aria-expanded={showFacetList ? "true" : "false"}
-        onClick={() => setShowFacetList(!showFacetList)}
+        onClick={() => {
+          setTransitioning(true)
+          setShowFacetList(!showFacetList)
+        }}
       >
         {title}
         <i aria-hidden="true">

--- a/src/facet_display/FilterableFacet.tsx
+++ b/src/facet_display/FilterableFacet.tsx
@@ -61,7 +61,11 @@ function FilterableFacet(props: Props) {
   return results && results.length === 0 ? null : (
     <div
       className={`facets filterable-facet${
-        showFacetList ? " facets-expanded" : (transitioning ? " facets-transitioning" : "")
+        showFacetList ?
+          " facets-expanded" :
+          transitioning ?
+            " facets-transitioning" :
+            ""
       }`}
       onTransitionEnd={() => setTransitioning(false)}
     >


### PR DESCRIPTION
### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/hq/issues/5421

### Description (What does it do?)
This PR sets up the collapsible facet containers to have a `facet-transitioning` class applied to the container. This allows consumers of the library to apply styles to the facet based on whether or not it has completed its expand / collapse transition.

### How can this be tested?
This is best tested with `mit-learn`; follow the instructions in this PR: https://github.com/mitodl/mit-open/pull/1698
