### PR TITLE
es2015 output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
         run: yarn fmt:check
 
       - name: Typescript build
-        run: yarn typescript
+        run: yarn build

--- a/package.json
+++ b/package.json
@@ -7,9 +7,21 @@
     "dist/"
   ],
   "exports": {
-    ".": "./dist/index.js",
-    "./react-router": "./dist/react-router/index.js",
-    "./next": "./dist/next/index.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./react-router": {
+      "import": "./dist/esm/react-router/index.js",
+      "require": "./dist/cjs/react-router/index.js",
+      "default": "./dist/esm/react-router/index.js"
+    },
+    "./next": {
+      "import": "./dist/esm/next/index.js",
+      "require": "./dist/cjs/next/index.js",
+      "default": "./dist/esm/next/index.js"
+    }
   },
   "scripts": {
     "test": "jest",
@@ -18,10 +30,12 @@
     "lint:cache": "eslint src --ext .js,.jsx,.ts,.tsx --cache",
     "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi $PWD/'src/**/*.ts' $PWD/'src/**/*.tsx'",
     "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi $PWD/'src/**/*.ts' $PWD/'src/**/*.tsx'",
-    "typescript": "rm -rf dist && rm -f .tsbuildinfo && tsc",
     "typecheck": "tsc --noEmit",
-    "prepack": "npm run typescript",
-    "repl": "ts-node"
+    "prepack": "npm run build",
+    "repl": "ts-node",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs",
+    "build": "rm -rf dist && rm -f .tsbuildinfo && npm run build:esm && npm run build:cjs"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "target": "es5",
-    "module": "commonjs",
+    "module": "ES2015",
     "lib": [
       "es2020",
       "dom"
@@ -11,7 +11,7 @@
     "checkJs": true,
     "jsx": "react",
     "declaration": true,
-    "outDir": "./dist/",
+    "outDir": "./dist/esm/",
     "tsBuildInfoFile": ".tsbuildinfo",
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
### What are the relevant tickets?
 - Resolves https://github.com/mitodl/hq/issues/5818

### Description (What does it do?)
This builds both ESM and CJS outputs.

```ts
// ESM
import { Whatever } from "some-package"
// CJS
const { Whatever }  = require("some-package")
```

- ESM outputs: These are better for our actual applications. With ESM outputs, bundlers can tree-shake the imports within the library.
    - Example: We recently added remixicon to course-search-utils, `import { RiArrowDownSLine, RiArrowUpSLine } from "@remixicon/react"`. With only CJS output, consuming applications could not tree-shake course-search-utils' copy of remixicon, which caused the whole library to be included in our application bundles. Ouch.
- CJS output: It's good for Jest, I guess, since Jest does not transpile things in node_modules

### How can this be tested?
1. CI should pass here
2. CI should pass here https://github.com/mitodl/mit-learn/pull/1707
3. Check out https://github.com/mitodl/mit-learn/pull/1707 locally and test search page

