### PR TITLE
add react 18 as peer dep option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,15 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v2
         with:
           node-version: 15.3.0
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "peerDependencies": {
     "@types/history": "^4.9",
     "history": "^4.9 || ^5.0.0",
-    "react": "^16.13.1"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "history": {


### PR DESCRIPTION
### What are the relevant tickets?
Helps https://github.com/mitodl/ocw-hugo-themes/pull/1522

### Description (What does it do?)
Adds React 18 as a possible peer dep.


### How can this be tested?
There are no code changes. based on @ibrahimjaved12 's testing in https://github.com/mitodl/ocw-hugo-themes/pull/1522, 18 works, so I'm going to merge this to avoid an npm install error there.

