### PR TITLE
Add department 21T (Theater Arts) to DEPARTMENTS

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,6 +22,7 @@ export const DEPARTMENTS = {
   "21H":   "History",
   "21L":   "Literature",
   "21M":   "Music and Theater Arts",
+  "21T":   "Theater Arts",
   22:      "Nuclear Science and Engineering",
   24:      "Linguistics and Philosophy",
   CC:      "Concourse",

--- a/src/hooks/validation.ts
+++ b/src/hooks/validation.ts
@@ -45,18 +45,16 @@ type QueryParamValidators<ReqParams> = {
   [k in keyof Required<ReqParams>]: (v: string[]) => ReqParams[k]
 }
 
+// "21T" (Theater Arts) isn't in the published mit-learn-api-axios DepartmentEnum yet,
+// so it's added here and cast to the enum value type. Remove once the openapi release ships.
 const PATCHED_DEPARTMENT_VALUES = [
   ...Object.values(DepartmentEnum),
   "21T"
-] as const
+] as (typeof DepartmentEnum)[keyof typeof DepartmentEnum][]
 
 const resourceSearchValidators: QueryParamValidators<ResourceSearchRequest> = {
   resource_type:              withinEnum(Object.values(ResourceTypeEnum)),
-  // "21T" (Theater Arts) isn't in the published mit-learn-api-axios DepartmentEnum yet,
-  // so cast to the expected validator type. Remove once the openapi release ships.
-  department: withinEnum(
-    Object.values(PATCHED_DEPARTMENT_VALUES)
-  ) as QueryParamValidators<ResourceSearchRequest>["department"],
+  department:                 withinEnum(Object.values(PATCHED_DEPARTMENT_VALUES)),
   level:                      withinEnum(Object.values(LevelEnum)),
   platform:                   withinEnum(Object.values(PlatformEnum)),
   offered_by:                 withinEnum(Object.values(OfferedByEnum)),

--- a/src/hooks/validation.ts
+++ b/src/hooks/validation.ts
@@ -45,9 +45,18 @@ type QueryParamValidators<ReqParams> = {
   [k in keyof Required<ReqParams>]: (v: string[]) => ReqParams[k]
 }
 
+const PATCHED_DEPARTMENT_VALUES = [
+  ...Object.values(DepartmentEnum),
+  "21T"
+] as const
+
 const resourceSearchValidators: QueryParamValidators<ResourceSearchRequest> = {
   resource_type:              withinEnum(Object.values(ResourceTypeEnum)),
-  department:                 withinEnum(Object.values(DepartmentEnum)),
+  // "21T" (Theater Arts) isn't in the published mit-learn-api-axios DepartmentEnum yet,
+  // so cast to the expected validator type. Remove once the openapi release ships.
+  department: withinEnum(
+    Object.values(PATCHED_DEPARTMENT_VALUES)
+  ) as QueryParamValidators<ResourceSearchRequest>["department"],
   level:                      withinEnum(Object.values(LevelEnum)),
   platform:                   withinEnum(Object.values(PlatformEnum)),
   offered_by:                 withinEnum(Object.values(OfferedByEnum)),


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Adds `21T` → `Theater Arts` to the `DEPARTMENTS` constant so the department facet label renders for the new department.

Needs https://github.com/mitodl/mit-learn/pull/3668 to go out before so that we can update mit-learn-api-axios properly.

### How can this be tested?
To be tested with https://github.com/mitodl/mit-learn/pull/3668. See the testing instructions for that PR

### Additional Context
Once this is merged, we'll bump the version of course-search-utils in https://github.com/mitodl/mit-learn/pull/3668 to include this change.
