### PR TITLE
Rename department 21M to Music

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const DEPARTMENTS = {
   "21G":   "Global Studies and Languages",
   "21H":   "History",
   "21L":   "Literature",
-  "21M":   "Music and Theater Arts",
+  "21M":   "Music",
   22:      "Nuclear Science and Engineering",
   24:      "Linguistics and Philosophy",
   CC:      "Concourse",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5616

### Description (What does it do?)
Renames the `21M` label in the `DEPARTMENTS` constant from "Music and Theater Arts" to **Music**.


### How can this be tested?
To be tested together with https://github.com/mitodl/mit-learn/pull/3669. See the testing instructions for that PR
